### PR TITLE
feat: invalidacao de cache sem forcar reload + telefoneJaCadastrado

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,6 +8,24 @@
         "headers": [
           { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" }
         ]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [
+          { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        ]
+      },
+      {
+        "source": "/index.html",
+        "headers": [
+          { "key": "Cache-Control", "value": "no-cache, max-age=0, must-revalidate" }
+        ]
+      },
+      {
+        "source": "/version.json",
+        "headers": [
+          { "key": "Cache-Control", "value": "no-cache, max-age=0, must-revalidate" }
+        ]
       }
     ],
     "rewrites": [

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -55,6 +55,26 @@ export const enviarNotificacao = onCall(async (request) => {
 })
 
 /**
+ * Cloud Function callable pública que verifica se um telefone (E.164)
+ * já está cadastrado em `usuarios`. Usada tanto no cadastro (para bloquear
+ * duplicatas) quanto no login por SMS (para não criar conta Auth órfã
+ * antes de saber se o usuário existe no bolão).
+ * Aceita: { telefone }
+ */
+export const telefoneJaCadastrado = onCall(async (request) => {
+  const { telefone } = request.data as { telefone?: string }
+  if (!telefone || typeof telefone !== 'string') {
+    throw new HttpsError('invalid-argument', 'telefone é obrigatório.')
+  }
+  const snap = await admin.firestore()
+    .collection('usuarios')
+    .where('telefone', '==', telefone)
+    .limit(1)
+    .get()
+  return { existe: !snap.empty }
+})
+
+/**
  * Cloud Function callable para admin excluir um usuário.
  * Faz backup completo em `usuarios_excluidos/{uid}` antes de remover.
  * Aceita: { uid }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { AdminRoute } from './components/AdminRoute'
 import { LiberadoRoute } from './components/LiberadoRoute'
 import { OfflineBanner } from './components/OfflineBanner'
 import { AmbienteTesteBanner } from './components/AmbienteTesteBanner'
+import { NovaVersaoBanner } from './components/NovaVersaoBanner'
 
 const Login = lazy(() => import('./pages/Login').then(m => ({ default: m.Login })))
 const Cadastro = lazy(() => import('./pages/Cadastro').then(m => ({ default: m.Cadastro })))
@@ -25,6 +26,7 @@ function AppContent() {
     <>
     <AmbienteTesteBanner />
     <OfflineBanner />
+    <NovaVersaoBanner />
     <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Carregando...</div>}>
       <Routes>
         <Route path="/login" element={<Login />} />

--- a/src/components/NovaVersaoBanner.tsx
+++ b/src/components/NovaVersaoBanner.tsx
@@ -1,0 +1,18 @@
+import { useAppVersion } from '../hooks/useAppVersion'
+
+export function NovaVersaoBanner() {
+  const { hasUpdate, reload } = useAppVersion()
+  if (!hasUpdate) return null
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 bg-blue-600 text-white rounded-full shadow-lg px-4 py-2 flex items-center gap-3 text-sm">
+      <span>Nova versão disponível.</span>
+      <button
+        onClick={reload}
+        className="bg-white text-blue-700 font-semibold rounded-full px-3 py-1 hover:bg-blue-50 transition-colors"
+      >
+        Atualizar
+      </button>
+    </div>
+  )
+}

--- a/src/hooks/useAppVersion.ts
+++ b/src/hooks/useAppVersion.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+
+const POLL_INTERVAL_MS = 2 * 60 * 1000
+
+export function useAppVersion() {
+  const [hasUpdate, setHasUpdate] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function check() {
+      try {
+        const res = await fetch(`/version.json?t=${Date.now()}`, { cache: 'no-store' })
+        if (!res.ok) return
+        const data = (await res.json()) as { version?: string }
+        if (cancelled) return
+        if (data.version && data.version !== __APP_VERSION__) {
+          setHasUpdate(true)
+        }
+      } catch {
+        // rede offline: ignora
+      }
+    }
+
+    check()
+    const id = window.setInterval(check, POLL_INTERVAL_MS)
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') check()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [])
+
+  return { hasUpdate, reload: () => window.location.reload() }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,38 @@ import { defineConfig, loadEnv, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { writeFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
 import path from 'node:path'
+
+function resolveAppVersion(): string {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim()
+  } catch {
+    return `build-${Date.now()}`
+  }
+}
+
+function appVersionJson(version: string): Plugin {
+  const payload = JSON.stringify({ version, buildTime: new Date().toISOString() })
+  return {
+    name: 'app-version-json',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.url?.split('?')[0] === '/version.json') {
+          res.setHeader('Content-Type', 'application/json')
+          res.setHeader('Cache-Control', 'no-cache, max-age=0, must-revalidate')
+          res.end(payload)
+          return
+        }
+        next()
+      })
+    },
+    writeBundle(options) {
+      const outDir = options.dir || 'dist'
+      writeFileSync(path.join(outDir, 'version.json'), payload)
+    },
+  }
+}
 
 function firebaseMessagingSw(env: Record<string, string>): Plugin {
   const buildContent = () => `importScripts('https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js')
@@ -48,12 +79,17 @@ messaging.onBackgroundMessage((payload) => {
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
+  const appVersion = resolveAppVersion()
   return {
     plugins: [
       react(),
       tailwindcss(),
       firebaseMessagingSw(env),
+      appVersionJson(appVersion),
     ],
+    define: {
+      __APP_VERSION__: JSON.stringify(appVersion),
+    },
     server: {
       headers: {
         'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',


### PR DESCRIPTION
## Summary
- Headers de cache no Firebase Hosting: `index.html`/`version.json` no-cache; `/assets/**` immutable 1y
- `version.json` gerado no build com git SHA curto + `__APP_VERSION__` injetado via `define`
- Hook `useAppVersion` faz polling de 2min + `visibilitychange`; exibe banner "Atualizar" se versão mudou
- Cloud Function `telefoneJaCadastrado` para checar duplicidade de telefone em `usuarios`

## Test plan
- [x] `vite build` passa e gera `dist/version.json`
- [x] `functions: tsc` passa
- [ ] Verificar no ambiente teste que após deploy aparece banner sem precisar F5
- [ ] Verificar cabeçalhos `Cache-Control` nos assets e index.html em prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)