### PR TITLE
fix(liberado): UI alinhada com a rule do Firestore (=== true)

### DIFF
--- a/src/components/BannerLiberacao.tsx
+++ b/src/components/BannerLiberacao.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '../hooks/useAuth'
 export function BannerLiberacao() {
   const { usuario } = useAuth()
 
-  if (!usuario || usuario.liberado !== false || usuario.role === 'admin') return null
+  if (!usuario || usuario.liberado === true || usuario.role === 'admin') return null
 
   return (
     <div className="sticky top-0 z-40 bg-amber-500 text-white px-4 py-3 text-center text-sm font-medium shadow-md">

--- a/src/components/LiberadoRoute.tsx
+++ b/src/components/LiberadoRoute.tsx
@@ -5,6 +5,6 @@ export function LiberadoRoute({ children }: { children: React.ReactNode }) {
   const { firebaseUser, usuario, loading } = useAuth()
   if (loading) return <div className="flex justify-center p-8">Carregando...</div>
   if (!firebaseUser) return <Navigate to="/login" replace />
-  if (usuario?.liberado === false) return <Navigate to="/" replace />
+  if (usuario && usuario.liberado !== true) return <Navigate to="/" replace />
   return <>{children}</>
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,7 @@ export function Navbar() {
 
   const isActive = (path: string) => location.pathname === path
 
-  const liberado = usuario?.liberado !== false
+  const liberado = usuario?.liberado === true
 
   const navLinks = [
     { to: '/palpites', label: 'Palpites' },

--- a/src/pages/PalpitesEspeciais.tsx
+++ b/src/pages/PalpitesEspeciais.tsx
@@ -49,7 +49,7 @@ export function PalpitesEspeciais() {
     load()
   }, [firebaseUser])
 
-  const naoLiberado = usuario?.liberado === false
+  const naoLiberado = usuario != null && usuario.liberado !== true
   const prazoExpirado = config?.prazoLimitePalpites
     ? Timestamp.now().toMillis() > config.prazoLimitePalpites.toMillis()
     : false

--- a/src/pages/PalpitesGrupos.tsx
+++ b/src/pages/PalpitesGrupos.tsx
@@ -133,7 +133,7 @@ export function PalpitesGrupos() {
   }
 
   const { usuario } = useAuth()
-  const naoLiberado = usuario?.liberado === false
+  const naoLiberado = usuario != null && usuario.liberado !== true
   const prazoExpirado = config ? config.prazoLimitePalpites.toDate() < new Date() : false
 
   if (loading) {

--- a/src/pages/PalpitesMataMata.tsx
+++ b/src/pages/PalpitesMataMata.tsx
@@ -245,7 +245,7 @@ export function PalpitesMataMata({ fase }: Props) {
   }
 
   const { usuario } = useAuth()
-  const naoLiberado = usuario?.liberado === false
+  const naoLiberado = usuario != null && usuario.liberado !== true
   const prazoExpirado = config ? config.prazoLimitePalpites.toDate() < new Date() : false
 
   if (loading) {

--- a/src/pages/admin/GerenciarUsuarios.tsx
+++ b/src/pages/admin/GerenciarUsuarios.tsx
@@ -167,27 +167,27 @@ export function GerenciarUsuarios() {
                 <td className="px-4 py-3">
                   <span
                     className={`text-xs font-semibold px-3 py-1 rounded-full ${
-                      u.liberado !== false
+                      u.liberado === true
                         ? 'bg-green-100 text-green-700'
                         : 'bg-red-100 text-red-700'
                     }`}
                   >
-                    {u.liberado !== false ? 'Liberado' : 'Pendente'}
+                    {u.liberado === true ? 'Liberado' : 'Pendente'}
                   </span>
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-1">
                     <button
                       onClick={() => toggleLiberado(u.uid, u.liberado ?? false)}
-                      title={u.liberado !== false ? 'Deixar pendente' : 'Liberar'}
-                      aria-label={u.liberado !== false ? 'Deixar pendente' : 'Liberar'}
+                      title={u.liberado === true ? 'Deixar pendente' : 'Liberar'}
+                      aria-label={u.liberado === true ? 'Deixar pendente' : 'Liberar'}
                       className={`p-1.5 rounded-lg border transition-colors ${
-                        u.liberado !== false
+                        u.liberado === true
                           ? 'border-red-300 text-red-700 hover:bg-red-50'
                           : 'border-green-300 text-green-700 hover:bg-green-50'
                       }`}
                     >
-                      {u.liberado !== false ? iconClock : iconCheck}
+                      {u.liberado === true ? iconClock : iconCheck}
                     </button>
                     <button
                       onClick={() => excluirUsuario(u)}
@@ -214,24 +214,24 @@ export function GerenciarUsuarios() {
                 <div className="flex items-center gap-2">
                   <span
                     className={`text-xs font-semibold px-3 py-1 rounded-full ${
-                      u.liberado !== false
+                      u.liberado === true
                         ? 'bg-green-100 text-green-700'
                         : 'bg-red-100 text-red-700'
                     }`}
                   >
-                    {u.liberado !== false ? 'Liberado' : 'Pendente'}
+                    {u.liberado === true ? 'Liberado' : 'Pendente'}
                   </span>
                   <button
                     onClick={() => toggleLiberado(u.uid, u.liberado ?? false)}
-                    title={u.liberado !== false ? 'Deixar pendente' : 'Liberar'}
-                    aria-label={u.liberado !== false ? 'Deixar pendente' : 'Liberar'}
+                    title={u.liberado === true ? 'Deixar pendente' : 'Liberar'}
+                    aria-label={u.liberado === true ? 'Deixar pendente' : 'Liberar'}
                     className={`p-1.5 rounded-lg border transition-colors ${
-                      u.liberado !== false
+                      u.liberado === true
                         ? 'border-red-300 text-red-700 hover:bg-red-50'
                         : 'border-green-300 text-green-700 hover:bg-green-50'
                     }`}
                   >
-                    {u.liberado !== false ? iconClock : iconCheck}
+                    {u.liberado === true ? iconClock : iconCheck}
                   </button>
                   <button
                     onClick={() => excluirUsuario(u)}


### PR DESCRIPTION
## Sumario

A rule \`isLiberado()\` exige \`liberado == true\` estritamente, mas a UI usava checks fracos (\`!== false\` em alguns lugares, \`=== false\` em outros) que tratavam o campo ausente de forma inconsistente. Resultado: admins viam usuarios como \"Liberado\" que o backend bloqueava no save de palpite.

## O que mudou

7 arquivos, 18 ocorrencias migradas para \`=== true\` / \`!== true\`:

- \`Navbar.tsx\` — \`liberado\` derivado coerente com a rule
- \`BannerLiberacao.tsx\` — banner some quando \`liberado === true\`
- \`LiberadoRoute.tsx\` — bloqueia rota se \`liberado !== true\`
- \`GerenciarUsuarios.tsx\` — coluna Status mostra \"Pendente\" quando o campo nao esta como \`true\`
- \`PalpitesGrupos.tsx\`, \`PalpitesMataMata.tsx\`, \`PalpitesEspeciais.tsx\` — \`naoLiberado\` agora bate com a rule (com guard \`usuario != null\` pra evitar flicker durante loading)

## Backfill ja aplicado em prod

3 usuarios em prod estavam com o campo ausente (criados antes de 21/abr quando o Cadastro.tsx passou a gravar \`liberado: false\`):

- Mussa (cyro@soldani.com.br)
- Mussa (cyrosoldani@hotmail.com)
- Tuga (Antonio Henrique)

Atualizados manualmente para \`liberado: true\` (UI ja os mostrava como \"Liberado\", entao essa era a intencao declarada do admin).

## Validacao

- \`npm test\`: 25/25
- \`npm run build\`: OK
- Hosting ja deployado em prod e teste com a correcao (commit \`ed807b1\` aplicado nos dois ambientes em modo \"fire-fix\" antes deste PR pra estancar o problema).

## Test plan

- [ ] Login em prod como participante novo: ve banner \"Aguardando liberacao\"
- [ ] Admin libera o usuario: status muda de Pendente para Liberado
- [ ] Usuario consegue palpitar
- [ ] Admin volta a Pendente: usuario perde acesso a /palpites
- [ ] Em /admin/usuarios, contagem de Pendentes/Liberados bate com o real

🤖 Generated with [Claude Code](https://claude.com/claude-code)