### PR TITLE
feat(observability): analytics, performance, remote config, audit log + alertas

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -185,6 +185,12 @@ service cloud.firestore {
       allow update: if false;
     }
 
+    // /audit_log/{logId}: leitura so admin, escrita so via Admin SDK (Cloud Functions)
+    match /audit_log/{logId} {
+      allow read: if isAdmin();
+      allow write: if false;
+    }
+
     // /ranking/{uid}: read by authenticated, write only by Cloud Functions via Admin SDK
     match /ranking/{uid} {
       allow read: if isAuthenticated();

--- a/functions/src/audit.ts
+++ b/functions/src/audit.ts
@@ -1,0 +1,117 @@
+import * as admin from 'firebase-admin'
+import { onDocumentWritten } from 'firebase-functions/v2/firestore'
+
+// audit_log centraliza eventos sensiveis em /audit_log/{autoId}.
+// Schema: {
+//   eventType: string,
+//   targetUid: string | null,
+//   targetPath: string,
+//   before: object | null,
+//   after: object | null,
+//   changedFields: string[],
+//   at: Timestamp
+// }
+//
+// Leitura via firestore.rules so para admin. Escrita so via Admin SDK.
+
+interface AuditDoc {
+  eventType: string
+  targetUid: string | null
+  targetPath: string
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+  changedFields: string[]
+  at: admin.firestore.Timestamp
+}
+
+function diffKeys(
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown> | null,
+): string[] {
+  const keys = new Set<string>([
+    ...(before ? Object.keys(before) : []),
+    ...(after ? Object.keys(after) : []),
+  ])
+  const changed: string[] = []
+  for (const k of keys) {
+    const a = before?.[k]
+    const b = after?.[k]
+    if (JSON.stringify(a) !== JSON.stringify(b)) changed.push(k)
+  }
+  return changed
+}
+
+async function gravar(doc: AuditDoc) {
+  await admin.firestore().collection('audit_log').add(doc)
+}
+
+// Palpites — captura create / update / delete
+export const auditPalpites = onDocumentWritten('palpites/{palpiteId}', async (event) => {
+  const before = event.data?.before.data() as Record<string, unknown> | undefined
+  const after = event.data?.after.data() as Record<string, unknown> | undefined
+
+  const eventType =
+    !before && after ? 'palpite_create'
+      : before && !after ? 'palpite_delete'
+        : 'palpite_update'
+
+  await gravar({
+    eventType,
+    targetUid: ((after?.uid ?? before?.uid) as string | undefined) ?? null,
+    targetPath: `palpites/${event.params.palpiteId}`,
+    before: before ?? null,
+    after: after ?? null,
+    changedFields: diffKeys(before ?? null, after ?? null),
+    at: admin.firestore.Timestamp.now(),
+  })
+})
+
+// Palpites especiais
+export const auditPalpitesEspeciais = onDocumentWritten('palpites_especiais/{uid}', async (event) => {
+  const before = event.data?.before.data() as Record<string, unknown> | undefined
+  const after = event.data?.after.data() as Record<string, unknown> | undefined
+
+  const eventType =
+    !before && after ? 'palpite_especial_create'
+      : before && !after ? 'palpite_especial_delete'
+        : 'palpite_especial_update'
+
+  await gravar({
+    eventType,
+    targetUid: event.params.uid,
+    targetPath: `palpites_especiais/${event.params.uid}`,
+    before: before ?? null,
+    after: after ?? null,
+    changedFields: diffKeys(before ?? null, after ?? null),
+    at: admin.firestore.Timestamp.now(),
+  })
+})
+
+// Usuarios — captura mudancas em campos sensiveis (liberado, role) ou criacao/exclusao
+const CAMPOS_SENSIVEIS_USUARIO = new Set(['liberado', 'role', 'fotoURL', 'apelido', 'nome', 'email', 'telefone'])
+
+export const auditUsuarios = onDocumentWritten('usuarios/{uid}', async (event) => {
+  const before = event.data?.before.data() as Record<string, unknown> | undefined
+  const after = event.data?.after.data() as Record<string, unknown> | undefined
+
+  const eventType =
+    !before && after ? 'usuario_create'
+      : before && !after ? 'usuario_delete'
+        : 'usuario_update'
+
+  const changedFields = diffKeys(before ?? null, after ?? null)
+  const houveSensivel = changedFields.some(f => CAMPOS_SENSIVEIS_USUARIO.has(f))
+
+  // Skip writes triviais (ex.: fcmToken refresh) para nao poluir o log
+  if (eventType === 'usuario_update' && !houveSensivel) return
+
+  await gravar({
+    eventType,
+    targetUid: event.params.uid,
+    targetPath: `usuarios/${event.params.uid}`,
+    before: before ?? null,
+    after: after ?? null,
+    changedFields,
+    at: admin.firestore.Timestamp.now(),
+  })
+})

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,6 +3,7 @@ import { onDocumentUpdated } from 'firebase-functions/v2/firestore'
 import { onCall, HttpsError } from 'firebase-functions/v2/https'
 import { recalcularTodoRanking } from './pontuacao'
 export { backupFirestoreDiario } from './backup'
+export { auditPalpites, auditPalpitesEspeciais, auditUsuarios } from './audit'
 
 admin.initializeApp()
 

--- a/scripts/setup-cloud-monitoring.sh
+++ b/scripts/setup-cloud-monitoring.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Cria canais de notificacao por email + alertas para
+# - Backup diario (backupFirestoreDiario) que falha
+# - Functions com erro acima de threshold em janela curta
+#
+# Uso:
+#   bash scripts/setup-cloud-monitoring.sh <projectId> <email>
+# Ex:
+#   bash scripts/setup-cloud-monitoring.sh bolao-do-bolero emerson.rocco@gmail.com
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Uso: bash scripts/setup-cloud-monitoring.sh <projectId> <email>"
+  exit 1
+fi
+
+PROJECT_ID="$1"
+EMAIL="$2"
+
+echo "==> Setando projeto ativo: $PROJECT_ID"
+gcloud config set project "$PROJECT_ID" --quiet
+
+# 1) Notification channel (email) — cria se nao existe
+echo "==> Verificando canal de notificacao por email..."
+EXISTING=$(gcloud alpha monitoring channels list \
+  --project "$PROJECT_ID" \
+  --filter="type=email AND labels.email_address=$EMAIL" \
+  --format="value(name)" 2>/dev/null | head -1)
+
+if [ -z "$EXISTING" ]; then
+  echo "==> Criando canal email -> $EMAIL"
+  CHANNEL_NAME=$(gcloud alpha monitoring channels create \
+    --project "$PROJECT_ID" \
+    --display-name="Email - $EMAIL" \
+    --type=email \
+    --channel-labels="email_address=$EMAIL" \
+    --format="value(name)")
+else
+  CHANNEL_NAME="$EXISTING"
+  echo "==> Canal ja existe: $CHANNEL_NAME"
+fi
+
+# Helper para criar policy a partir de YAML inline
+function criar_alerta() {
+  local DISPLAY_NAME="$1"
+  local YAML_FILE="$2"
+
+  EXISTING_POLICY=$(gcloud alpha monitoring policies list \
+    --project "$PROJECT_ID" \
+    --filter="displayName=\"$DISPLAY_NAME\"" \
+    --format="value(name)" 2>/dev/null | head -1)
+
+  if [ -n "$EXISTING_POLICY" ]; then
+    echo "==> Alerta '$DISPLAY_NAME' ja existe: $EXISTING_POLICY (skip)"
+    return 0
+  fi
+
+  echo "==> Criando alerta: $DISPLAY_NAME"
+  gcloud alpha monitoring policies create \
+    --project "$PROJECT_ID" \
+    --policy-from-file="$YAML_FILE" \
+    --notification-channels="$CHANNEL_NAME" >/dev/null
+}
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+# 2) Alerta: Cloud Function com erro nas ultimas 5 min
+cat > "$TMPDIR/policy-functions-error.yaml" <<EOF
+displayName: "Cloud Functions - erros nas ultimas 5min"
+combiner: OR
+conditions:
+  - displayName: "Function errors > 0"
+    conditionThreshold:
+      filter: 'metric.type="cloudfunctions.googleapis.com/function/execution_count" AND resource.type="cloud_function" AND metric.labels.status!="ok"'
+      aggregations:
+        - alignmentPeriod: 300s
+          perSeriesAligner: ALIGN_SUM
+          crossSeriesReducer: REDUCE_SUM
+          groupByFields:
+            - resource.label.function_name
+      comparison: COMPARISON_GT
+      thresholdValue: 0
+      duration: 0s
+      trigger:
+        count: 1
+documentation:
+  content: "Uma ou mais Cloud Functions falharam. Veja logs em https://console.firebase.google.com/project/$PROJECT_ID/functions/logs"
+  mimeType: "text/markdown"
+alertStrategy:
+  autoClose: 1800s
+EOF
+criar_alerta "Cloud Functions - erros nas ultimas 5min" "$TMPDIR/policy-functions-error.yaml"
+
+# 3) Alerta: backup diario nao executado em 26h (horario diario as 00:00 BRT)
+cat > "$TMPDIR/policy-backup-missing.yaml" <<EOF
+displayName: "Backup Firestore - nao executou em 26h"
+combiner: OR
+conditions:
+  - displayName: "backupFirestoreDiario sem execucoes recentes"
+    conditionAbsent:
+      filter: 'metric.type="cloudfunctions.googleapis.com/function/execution_count" AND resource.type="cloud_function" AND resource.label.function_name="backupFirestoreDiario"'
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_SUM
+          crossSeriesReducer: REDUCE_SUM
+      duration: 93600s
+documentation:
+  content: "A funcao backupFirestoreDiario nao executou nas ultimas 26h. Esperado: 1x ao dia as 00:00 BRT (03:00 UTC)."
+  mimeType: "text/markdown"
+alertStrategy:
+  autoClose: 86400s
+EOF
+criar_alerta "Backup Firestore - nao executou em 26h" "$TMPDIR/policy-backup-missing.yaml"
+
+echo ""
+echo "==> OK. Canais e alertas configurados em $PROJECT_ID."
+echo "    Verifique em: https://console.cloud.google.com/monitoring/alerting/policies?project=$PROJECT_ID"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { LiberadoRoute } from './components/LiberadoRoute'
 import { OfflineBanner } from './components/OfflineBanner'
 import { AmbienteTesteBanner } from './components/AmbienteTesteBanner'
 import { NovaVersaoBanner } from './components/NovaVersaoBanner'
+import { useAnalyticsTracking } from './hooks/useAnalytics'
 
 const Login = lazy(() => import('./pages/Login').then(m => ({ default: m.Login })))
 const Cadastro = lazy(() => import('./pages/Cadastro').then(m => ({ default: m.Cadastro })))
@@ -22,6 +23,7 @@ const Perfil = lazy(() => import('./pages/Perfil').then(m => ({ default: m.Perfi
 const VerificarVinculo = lazy(() => import('./pages/VerificarVinculo').then(m => ({ default: m.VerificarVinculo })))
 
 function AppContent() {
+  useAnalyticsTracking()
   return (
     <>
     <AmbienteTesteBanner />

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -3,6 +3,9 @@ import { getAuth } from 'firebase/auth'
 import { getFirestore } from 'firebase/firestore'
 import { getMessaging, isSupported } from 'firebase/messaging'
 import { getStorage } from 'firebase/storage'
+import { getAnalytics, isSupported as isAnalyticsSupported, type Analytics } from 'firebase/analytics'
+import { getPerformance, type FirebasePerformance } from 'firebase/performance'
+import { getRemoteConfig, fetchAndActivate, type RemoteConfig } from 'firebase/remote-config'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -11,6 +14,7 @@ const firebaseConfig = {
   storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
 }
 
 const app = initializeApp(firebaseConfig)
@@ -18,3 +22,47 @@ export const auth = getAuth(app)
 export const db = getFirestore(app)
 export const storage = getStorage(app)
 export const messaging = async () => (await isSupported()) ? getMessaging(app) : null
+
+// Analytics — so inicializa em ambientes que suportam (web seguro, sem extensoes
+// bloqueando, etc.). isAnalyticsSupported retorna false em SSR/iframes restritos.
+let analyticsInstance: Analytics | null = null
+isAnalyticsSupported().then((ok) => {
+  if (ok && firebaseConfig.measurementId) {
+    analyticsInstance = getAnalytics(app)
+  }
+}).catch(() => {})
+export const getAnalyticsInstance = () => analyticsInstance
+
+// Performance Monitoring — auto-coleta web vitals e traces de fetch/XHR.
+let performanceInstance: FirebasePerformance | null = null
+try {
+  performanceInstance = getPerformance(app)
+} catch {
+  // Ambiente nao suportado (SSR, etc) — falha silencioso
+}
+export const getPerformanceInstance = () => performanceInstance
+
+// Remote Config — feature flags e configuracoes remotas.
+// Inicializacao lazy via fetchAndActivate(), feita no useRemoteConfig hook.
+const remoteConfigInstance: RemoteConfig = (() => {
+  const rc = getRemoteConfig(app)
+  rc.settings.minimumFetchIntervalMillis = 5 * 60 * 1000  // 5 min em prod
+  return rc
+})()
+
+export const remoteConfig = remoteConfigInstance
+
+// Defaults dos flags. Servem como fallback se Remote Config nao baixou.
+export const REMOTE_CONFIG_DEFAULTS: Record<string, string | number | boolean> = {
+  feature_home_enriched: true,
+}
+remoteConfig.defaultConfig = REMOTE_CONFIG_DEFAULTS
+
+// Helper de inicializacao: chama fetchAndActivate uma vez na app.
+let rcReady: Promise<void> | null = null
+export function ensureRemoteConfig(): Promise<void> {
+  if (!rcReady) {
+    rcReady = fetchAndActivate(remoteConfig).then(() => {}).catch(() => {})
+  }
+  return rcReady
+}

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { logEvent, setUserId } from 'firebase/analytics'
+import { getAnalyticsInstance } from '../config/firebase'
+import { useAuth } from './useAuth'
+
+// Hook de tracking de SPA: registra page_view a cada mudanca de rota e
+// associa o uid do usuario logado para retencao/funil.
+export function useAnalyticsTracking() {
+  const location = useLocation()
+  const { firebaseUser } = useAuth()
+
+  useEffect(() => {
+    const a = getAnalyticsInstance()
+    if (!a) return
+    logEvent(a, 'page_view', {
+      page_path: location.pathname + location.search,
+      page_location: window.location.href,
+      page_title: document.title,
+    })
+  }, [location.pathname, location.search])
+
+  useEffect(() => {
+    const a = getAnalyticsInstance()
+    if (!a) return
+    setUserId(a, firebaseUser?.uid ?? null)
+  }, [firebaseUser?.uid])
+}
+
+// Helper para eventos custom do bolao (palpite_salvo, ranking_visto, etc.)
+export function trackEvent(name: string, params: Record<string, unknown> = {}) {
+  const a = getAnalyticsInstance()
+  if (!a) return
+  logEvent(a, name as 'select_content', params)
+}

--- a/src/hooks/useRemoteConfig.ts
+++ b/src/hooks/useRemoteConfig.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+import { getValue } from 'firebase/remote-config'
+import { remoteConfig, ensureRemoteConfig, REMOTE_CONFIG_DEFAULTS } from '../config/firebase'
+
+// Hook para ler uma flag do Remote Config. Retorna o valor atual (default
+// enquanto o fetchAndActivate nao termina, valor remoto depois).
+//
+// Uso:
+//   const homeEnriched = useRemoteFlag('feature_home_enriched', true)
+export function useRemoteFlag<T extends boolean | string | number>(
+  key: string,
+  fallback: T,
+): T {
+  const [value, setValue] = useState<T>(() => readValue(key, fallback))
+
+  useEffect(() => {
+    let cancelled = false
+    ensureRemoteConfig().then(() => {
+      if (cancelled) return
+      setValue(readValue(key, fallback))
+    })
+    return () => { cancelled = true }
+  }, [key, fallback])
+
+  return value
+}
+
+function readValue<T extends boolean | string | number>(key: string, fallback: T): T {
+  try {
+    const v = getValue(remoteConfig, key)
+    if (typeof fallback === 'boolean') return v.asBoolean() as T
+    if (typeof fallback === 'number') return v.asNumber() as T
+    return v.asString() as T
+  } catch {
+    return (REMOTE_CONFIG_DEFAULTS[key] as T) ?? fallback
+  }
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { auth, db } from '../config/firebase'
 import { useAuth } from '../hooks/useAuth'
 import { Navbar } from '../components/Navbar'
 import { AoVivo } from '../components/AoVivo'
+import { useRemoteFlag } from '../hooks/useRemoteConfig'
 import type { Jogo, Time, Ranking as RankingType } from '../types'
 
 function ContagemRegressiva({ dataAlvo }: { dataAlvo: Date }) {
@@ -53,6 +54,7 @@ export function Home() {
   const perfilIncompleto = usuario &&
     ((usuario.nome?.trim()?.length ?? 0) < 2 || (usuario.apelido?.trim()?.length ?? 0) < 2)
   const liberado = usuario?.liberado === true
+  const homeEnriched = useRemoteFlag('feature_home_enriched', true)
 
   useEffect(() => {
     async function load() {
@@ -113,7 +115,7 @@ export function Home() {
         </h1>
         <p className="text-gray-500 mb-6">O que você quer fazer hoje?</p>
 
-        {usuario && <AoVivo uid={usuario.uid} />}
+        {homeEnriched && usuario && <AoVivo uid={usuario.uid} />}
 
         {perfilIncompleto && (
           <Link
@@ -124,14 +126,14 @@ export function Home() {
           </Link>
         )}
 
-        {dataCopa.getTime() > Date.now() && (
+        {homeEnriched && dataCopa.getTime() > Date.now() && (
           <div className="bg-white rounded-xl shadow border border-gray-100 p-5 mb-6 text-center">
             <p className="text-xs text-gray-500 uppercase tracking-wide mb-2">Copa do Mundo 2026</p>
             <ContagemRegressiva dataAlvo={dataCopa} />
           </div>
         )}
 
-        {liberado && (
+        {homeEnriched && liberado && (
           <div className="grid grid-cols-3 gap-3 mb-6">
             <div className="bg-white rounded-xl shadow border border-gray-100 p-4 text-center">
               <p className="text-2xl font-black text-blue-700">{posicaoRanking ?? '-'}<span className="text-sm font-normal text-gray-400">/{totalParticipantes || '-'}</span></p>
@@ -148,7 +150,7 @@ export function Home() {
           </div>
         )}
 
-        {proximosJogos.length > 0 && (
+        {homeEnriched && proximosJogos.length > 0 && (
           <div className="bg-white rounded-xl shadow border border-gray-100 p-5 mb-6">
             <h2 className="text-sm font-bold text-gray-700 mb-3">Próximos jogos</h2>
             <div className="space-y-2">


### PR DESCRIPTION
Implementacao dos itens 1-4 do plano de observabilidade + audit log granular.

**Frontend** (sem mudanca visivel ao usuario):
- Firebase Analytics (GA4) — page_view automatico em mudanca de rota com user_id setado
- Performance Monitoring — auto-coleta web vitals + traces HTTP
- Remote Config + primeira flag em uso: `feature_home_enriched` (default true). Permite kill-switch da Home enriquecida sem deploy.

**Backend (Cloud Functions)**:
- 3 triggers de audit em `audit_log/{autoId}`:
  - palpites (create/update/delete)
  - palpites_especiais (create/update/delete)
  - usuarios (so quando campos sensiveis mudam)

**Infra**:
- `scripts/setup-cloud-monitoring.sh` cria alertas: Cloud Functions erros + backup diario nao executado em 26h. Idempotente. Manda para email configurado.

**Rules**:
- `/audit_log/{logId}`: read so admin, write so via Admin SDK.

Validado: `npm test` 25/25, builds OK.