### PR TITLE
feat: painel admin de auditoria + resolucao do mata-mata

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,30 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventType", "order": "ASCENDING" },
+        { "fieldPath": "at", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "targetUid", "order": "ASCENDING" },
+        { "fieldPath": "at", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "eventType", "order": "ASCENDING" },
+        { "fieldPath": "targetUid", "order": "ASCENDING" },
+        { "fieldPath": "at", "order": "DESCENDING" }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,6 +4,7 @@ import { onCall, HttpsError } from 'firebase-functions/v2/https'
 import { recalcularTodoRanking } from './pontuacao'
 export { backupFirestoreDiario } from './backup'
 export { auditPalpites, auditPalpitesEspeciais, auditUsuarios } from './audit'
+export { resolverMataMata } from './resolverMataMata'
 
 admin.initializeApp()
 

--- a/functions/src/resolverMataMata.ts
+++ b/functions/src/resolverMataMata.ts
@@ -1,0 +1,342 @@
+// Cloud Function callable que resolve os times do mata-mata a partir dos
+// resultados REAIS dos jogos (nao palpites).
+//
+// Le todos os jogos, calcula:
+// - classificacao final de cada grupo (criterios FIFA)
+// - 8 melhores 3os colocados (criterios FIFA)
+// Depois resolve cada label (1A, 2B, 3ABCDF, W73, RU101) para um timeId real
+// e atualiza os jogos do mata-mata cujo timeCasa/timeVisitante ainda esta vazio.
+//
+// Idempotente: pode rodar varias vezes; so atualiza jogos com label resolvivel
+// que ainda estao vazios.
+
+import * as admin from 'firebase-admin'
+import { onCall, HttpsError } from 'firebase-functions/v2/https'
+
+interface ResultadoJogo {
+  golsCasa: number
+  golsVisitante: number
+  classificadoNosPenaltis?: string
+}
+
+interface JogoData {
+  id: string
+  numero: number
+  fase: string
+  grupo?: string | null
+  timeCasa?: string
+  timeVisitante?: string
+  labelCasa?: string
+  labelVisitante?: string
+  encerrado?: boolean
+  resultado?: ResultadoJogo | null
+}
+
+interface ClassificacaoTime {
+  timeId: string
+  pontos: number
+  jogos: number
+  vitorias: number
+  empates: number
+  derrotas: number
+  golsMarcados: number
+  golsSofridos: number
+  saldoGols: number
+  grupo: string
+}
+
+// ---- Classificacao do grupo (criterios FIFA: pontos, saldo, gols, mini-tabela) ----
+
+function calcularClassificacaoGrupo(
+  jogosGrupo: JogoData[],
+  timesDoGrupo: string[],
+  grupoLetra: string,
+): ClassificacaoTime[] {
+  const map = new Map<string, ClassificacaoTime>()
+  for (const t of timesDoGrupo) {
+    map.set(t, { timeId: t, pontos: 0, jogos: 0, vitorias: 0, empates: 0, derrotas: 0,
+      golsMarcados: 0, golsSofridos: 0, saldoGols: 0, grupo: grupoLetra })
+  }
+
+  for (const j of jogosGrupo) {
+    if (!j.encerrado || !j.resultado || !j.timeCasa || !j.timeVisitante) continue
+    const c = map.get(j.timeCasa); const v = map.get(j.timeVisitante)
+    if (!c || !v) continue
+    c.jogos++; v.jogos++
+    c.golsMarcados += j.resultado.golsCasa; c.golsSofridos += j.resultado.golsVisitante
+    v.golsMarcados += j.resultado.golsVisitante; v.golsSofridos += j.resultado.golsCasa
+    if (j.resultado.golsCasa > j.resultado.golsVisitante) {
+      c.pontos += 3; c.vitorias++; v.derrotas++
+    } else if (j.resultado.golsCasa < j.resultado.golsVisitante) {
+      v.pontos += 3; v.vitorias++; c.derrotas++
+    } else { c.pontos++; v.pontos++; c.empates++; v.empates++ }
+    c.saldoGols = c.golsMarcados - c.golsSofridos
+    v.saldoGols = v.golsMarcados - v.golsSofridos
+  }
+
+  const lista = Array.from(map.values())
+  lista.sort(compararCriteriosGerais)
+  return aplicarMiniTabelaEntreEmpatados(lista, jogosGrupo)
+}
+
+function compararCriteriosGerais(a: ClassificacaoTime, b: ClassificacaoTime): number {
+  if (b.pontos !== a.pontos) return b.pontos - a.pontos
+  if (b.saldoGols !== a.saldoGols) return b.saldoGols - a.saldoGols
+  if (b.golsMarcados !== a.golsMarcados) return b.golsMarcados - a.golsMarcados
+  return 0
+}
+
+function mesmosCriteriosGerais(a: ClassificacaoTime, b: ClassificacaoTime): boolean {
+  return a.pontos === b.pontos && a.saldoGols === b.saldoGols && a.golsMarcados === b.golsMarcados
+}
+
+function aplicarMiniTabelaEntreEmpatados(
+  lista: ClassificacaoTime[],
+  jogosGrupo: JogoData[],
+): ClassificacaoTime[] {
+  const r = [...lista]
+  let i = 0
+  while (i < r.length) {
+    let j = i + 1
+    while (j < r.length && mesmosCriteriosGerais(r[i], r[j])) j++
+    if (j - i > 1) {
+      const empatados = r.slice(i, j).map(t => t.timeId)
+      const ordemMini = ordenarPorMiniTabela(empatados, jogosGrupo)
+      const porId = new Map(r.map(t => [t.timeId, t]))
+      for (let k = 0; k < ordemMini.length; k++) {
+        const original = porId.get(ordemMini[k])
+        if (original) r[i + k] = original
+      }
+    }
+    i = j
+  }
+  return r
+}
+
+function ordenarPorMiniTabela(times: string[], jogos: JogoData[]): string[] {
+  const setT = new Set(times)
+  const stat = new Map<string, ClassificacaoTime>()
+  for (const t of times) stat.set(t, { timeId: t, pontos: 0, jogos: 0, vitorias: 0, empates: 0, derrotas: 0, golsMarcados: 0, golsSofridos: 0, saldoGols: 0, grupo: '' })
+
+  for (const j of jogos) {
+    if (!j.encerrado || !j.resultado || !j.timeCasa || !j.timeVisitante) continue
+    if (!setT.has(j.timeCasa) || !setT.has(j.timeVisitante)) continue
+    const c = stat.get(j.timeCasa)!; const v = stat.get(j.timeVisitante)!
+    c.golsMarcados += j.resultado.golsCasa; c.golsSofridos += j.resultado.golsVisitante
+    v.golsMarcados += j.resultado.golsVisitante; v.golsSofridos += j.resultado.golsCasa
+    if (j.resultado.golsCasa > j.resultado.golsVisitante) { c.pontos += 3 }
+    else if (j.resultado.golsCasa < j.resultado.golsVisitante) { v.pontos += 3 }
+    else { c.pontos++; v.pontos++ }
+    c.saldoGols = c.golsMarcados - c.golsSofridos
+    v.saldoGols = v.golsMarcados - v.golsSofridos
+  }
+
+  return Array.from(stat.values()).sort(compararCriteriosGerais).map(t => t.timeId)
+}
+
+// ---- Comparador de 3os colocados (FIFA) ----
+function compararTerceiros(a: ClassificacaoTime, b: ClassificacaoTime): number {
+  if (b.pontos !== a.pontos) return b.pontos - a.pontos
+  if (b.saldoGols !== a.saldoGols) return b.saldoGols - a.saldoGols
+  if (b.golsMarcados !== a.golsMarcados) return b.golsMarcados - a.golsMarcados
+  if (a.grupo !== b.grupo) return a.grupo.localeCompare(b.grupo)
+  return a.timeId.localeCompare(b.timeId)
+}
+
+// ---- Resolver labels para timeIds ----
+
+interface ContextoResolver {
+  classificacoesPorGrupo: Record<string, ClassificacaoTime[]>
+  melhoresTerceiros: ClassificacaoTime[]
+  jogosByNumero: Map<number, JogoData>
+}
+
+function resolverGanhador(j: JogoData): string | null {
+  if (!j.encerrado || !j.resultado || !j.timeCasa || !j.timeVisitante) return null
+  if (j.resultado.golsCasa > j.resultado.golsVisitante) return j.timeCasa
+  if (j.resultado.golsVisitante > j.resultado.golsCasa) return j.timeVisitante
+  return j.resultado.classificadoNosPenaltis ?? null
+}
+
+function resolverPerdedor(j: JogoData): string | null {
+  const w = resolverGanhador(j)
+  if (!w || !j.timeCasa || !j.timeVisitante) return null
+  return w === j.timeCasa ? j.timeVisitante : j.timeCasa
+}
+
+function resolverLabelSimples(label: string, ctx: ContextoResolver): string | null {
+  const clean = label.trim().toUpperCase().replace(/\s+/g, '')
+
+  // Posicao em grupo: 1A, 2B
+  let m = clean.match(/^([12])([A-L])$/)
+  if (m) {
+    const pos = Number(m[1])
+    const cl = ctx.classificacoesPorGrupo[m[2]]
+    return cl && cl.length >= pos ? cl[pos - 1].timeId : null
+  }
+
+  // 3o de um grupo especifico (raro): 3A, 3B
+  m = clean.match(/^3([A-L])$/)
+  if (m) {
+    const cl = ctx.classificacoesPorGrupo[m[1]]
+    return cl && cl.length >= 3 ? cl[2].timeId : null
+  }
+
+  // Vencedor / perdedor de jogo
+  m = clean.match(/^(W|L|RU)(\d+)$/)
+  if (m) {
+    const j = ctx.jogosByNumero.get(Number(m[2]))
+    if (!j) return null
+    return m[1] === 'W' ? resolverGanhador(j) : resolverPerdedor(j)
+  }
+
+  return null
+}
+
+// Slots de "3o de um conjunto de grupos": atribuicao via bipartite matching greedy
+// usando a ordem dos melhoresTerceiros.
+interface SlotTerceiro { jogoId: string; lado: 'casa' | 'visitante'; gruposPermitidos: string[] }
+
+function montarMapaTerceirosPorSlot(
+  jogosFase32: JogoData[],
+  ctx: ContextoResolver,
+): Map<string, string> {
+  const slots: SlotTerceiro[] = []
+  const jogosOrdenados = [...jogosFase32].sort((a, b) => a.numero - b.numero)
+  for (const j of jogosOrdenados) {
+    for (const lado of ['casa', 'visitante'] as const) {
+      const label = (lado === 'casa' ? j.labelCasa : j.labelVisitante)?.trim().toUpperCase().replace(/\s+/g, '')
+      const m = label?.match(/^3([A-L]+)$/)
+      if (!m || m[1].length < 2) continue
+      slots.push({ jogoId: j.id, lado, gruposPermitidos: m[1].split('') })
+    }
+  }
+
+  const melhoresIds = new Set(ctx.melhoresTerceiros.map(t => t.timeId))
+  const ranking = new Map(ctx.melhoresTerceiros.map((t, i) => [t.timeId, i]))
+  const terceirosPorGrupo = new Map<string, ClassificacaoTime>()
+  for (const [grupo, cl] of Object.entries(ctx.classificacoesPorGrupo)) {
+    const t = cl[2]
+    if (t && melhoresIds.has(t.timeId)) terceirosPorGrupo.set(grupo, t)
+  }
+
+  const out = new Map<string, string>()
+  const usados = new Set<string>()
+
+  function tentar(idx: number): boolean {
+    if (idx >= slots.length) return true
+    const s = slots[idx]
+    const candidatos = s.gruposPermitidos
+      .map(g => terceirosPorGrupo.get(g))
+      .filter((t): t is ClassificacaoTime => t != null && !usados.has(t.timeId))
+      .sort((a, b) => (ranking.get(a.timeId) ?? 999) - (ranking.get(b.timeId) ?? 999))
+
+    for (const c of candidatos) {
+      out.set(`${s.jogoId}:${s.lado}`, c.timeId)
+      usados.add(c.timeId)
+      if (tentar(idx + 1)) return true
+      usados.delete(c.timeId)
+      out.delete(`${s.jogoId}:${s.lado}`)
+    }
+    return false
+  }
+
+  tentar(0)
+  return out
+}
+
+// ---- Callable principal ----
+
+export const resolverMataMata = onCall(async (request) => {
+  const callerUid = request.auth?.uid
+  if (!callerUid) throw new HttpsError('unauthenticated', 'Não autenticado.')
+
+  const db = admin.firestore()
+  const callerSnap = await db.doc(`usuarios/${callerUid}`).get()
+  if (callerSnap.data()?.role !== 'admin') {
+    throw new HttpsError('permission-denied', 'Apenas administradores.')
+  }
+
+  const jogosSnap = await db.collection('jogos').get()
+  const jogos: JogoData[] = jogosSnap.docs.map(d => ({ id: d.id, ...d.data() } as JogoData))
+
+  // Verificar se fase de grupos esta toda encerrada
+  const grupos = jogos.filter(j => j.fase === 'grupos')
+  const gruposEncerrados = grupos.filter(j => j.encerrado && j.resultado)
+  if (gruposEncerrados.length < grupos.length) {
+    return {
+      ok: false,
+      motivo: 'fase_grupos_incompleta',
+      gruposEncerrados: gruposEncerrados.length,
+      gruposTotal: grupos.length,
+    }
+  }
+
+  // Calcular classificacoes por grupo
+  const porGrupo: Record<string, JogoData[]> = {}
+  for (const j of grupos) {
+    const g = j.grupo ?? '?'
+    if (!porGrupo[g]) porGrupo[g] = []
+    porGrupo[g].push(j)
+  }
+
+  const classificacoesPorGrupo: Record<string, ClassificacaoTime[]> = {}
+  for (const [g, lista] of Object.entries(porGrupo)) {
+    const times = Array.from(new Set(lista.flatMap(j => [j.timeCasa, j.timeVisitante]).filter((x): x is string => !!x)))
+    classificacoesPorGrupo[g] = calcularClassificacaoGrupo(lista, times, g)
+  }
+
+  // 8 melhores 3os
+  const terceiros = Object.values(classificacoesPorGrupo)
+    .map(cl => cl[2])
+    .filter((t): t is ClassificacaoTime => t != null)
+    .sort(compararTerceiros)
+  const melhoresTerceiros = terceiros.slice(0, 8)
+
+  const jogosByNumero = new Map<number, JogoData>(jogos.map(j => [j.numero, j]))
+
+  const ctx: ContextoResolver = { classificacoesPorGrupo, melhoresTerceiros, jogosByNumero }
+
+  // Atribuicao dos slots de 3o-em-conjunto-de-grupos (so fase32)
+  const fase32 = jogos.filter(j => j.fase === 'fase32')
+  const terceirosPorSlot = montarMapaTerceirosPorSlot(fase32, ctx)
+
+  // Resolver e atualizar
+  const mataMata = jogos.filter(j => j.fase !== 'grupos')
+  let atualizados = 0
+  let pendentes = 0
+  const batch = db.batch()
+
+  for (const j of mataMata) {
+    const update: Record<string, string> = {}
+
+    if (!j.timeCasa && j.labelCasa) {
+      const slotKey = `${j.id}:casa`
+      const fromSlot = terceirosPorSlot.get(slotKey)
+      const id = fromSlot ?? resolverLabelSimples(j.labelCasa, ctx)
+      if (id) update.timeCasa = id
+    }
+    if (!j.timeVisitante && j.labelVisitante) {
+      const slotKey = `${j.id}:visitante`
+      const fromSlot = terceirosPorSlot.get(slotKey)
+      const id = fromSlot ?? resolverLabelSimples(j.labelVisitante, ctx)
+      if (id) update.timeVisitante = id
+    }
+
+    if (Object.keys(update).length > 0) {
+      batch.update(db.doc(`jogos/${j.id}`), update)
+      atualizados++
+    } else if ((!j.timeCasa && j.labelCasa) || (!j.timeVisitante && j.labelVisitante)) {
+      pendentes++
+    }
+  }
+
+  if (atualizados > 0) await batch.commit()
+
+  return {
+    ok: true,
+    atualizados,
+    pendentes,
+    melhoresTerceirosIds: melhoresTerceiros.map(t => t.timeId),
+  }
+})

--- a/scripts/setup-cloud-monitoring.sh
+++ b/scripts/setup-cloud-monitoring.sh
@@ -23,14 +23,14 @@ gcloud config set project "$PROJECT_ID" --quiet
 
 # 1) Notification channel (email) — cria se nao existe
 echo "==> Verificando canal de notificacao por email..."
-EXISTING=$(gcloud alpha monitoring channels list \
+EXISTING=$(gcloud beta monitoring channels list \
   --project "$PROJECT_ID" \
-  --filter="type=email AND labels.email_address=$EMAIL" \
-  --format="value(name)" 2>/dev/null | head -1)
+  --format="value(name,type,labels)" 2>/dev/null \
+  | { grep -F "$EMAIL" || true; } | { grep -F "email" || true; } | awk '{print $1}' | head -1)
 
 if [ -z "$EXISTING" ]; then
   echo "==> Criando canal email -> $EMAIL"
-  CHANNEL_NAME=$(gcloud alpha monitoring channels create \
+  CHANNEL_NAME=$(gcloud beta monitoring channels create \
     --project "$PROJECT_ID" \
     --display-name="Email - $EMAIL" \
     --type=email \
@@ -46,10 +46,10 @@ function criar_alerta() {
   local DISPLAY_NAME="$1"
   local YAML_FILE="$2"
 
-  EXISTING_POLICY=$(gcloud alpha monitoring policies list \
+  EXISTING_POLICY=$(gcloud beta monitoring policies list \
     --project "$PROJECT_ID" \
-    --filter="displayName=\"$DISPLAY_NAME\"" \
-    --format="value(name)" 2>/dev/null | head -1)
+    --format="value(name,displayName)" 2>/dev/null \
+    | { grep -F "$DISPLAY_NAME" || true; } | awk '{print $1}' | head -1)
 
   if [ -n "$EXISTING_POLICY" ]; then
     echo "==> Alerta '$DISPLAY_NAME' ja existe: $EXISTING_POLICY (skip)"
@@ -57,7 +57,7 @@ function criar_alerta() {
   fi
 
   echo "==> Criando alerta: $DISPLAY_NAME"
-  gcloud alpha monitoring policies create \
+  gcloud beta monitoring policies create \
     --project "$PROJECT_ID" \
     --policy-from-file="$YAML_FILE" \
     --notification-channels="$CHANNEL_NAME" >/dev/null
@@ -105,9 +105,9 @@ conditions:
         - alignmentPeriod: 60s
           perSeriesAligner: ALIGN_SUM
           crossSeriesReducer: REDUCE_SUM
-      duration: 93600s
+      duration: 84600s
 documentation:
-  content: "A funcao backupFirestoreDiario nao executou nas ultimas 26h. Esperado: 1x ao dia as 00:00 BRT (03:00 UTC)."
+  content: "A funcao backupFirestoreDiario nao executou nas ultimas 23h30. Esperado: 1x ao dia as 00:00 BRT (03:00 UTC)."
   mimeType: "text/markdown"
 alertStrategy:
   autoClose: 86400s

--- a/src/pages/PalpitesGeral.tsx
+++ b/src/pages/PalpitesGeral.tsx
@@ -5,16 +5,20 @@ import { db } from '../config/firebase'
 import { useAuth } from '../hooks/useAuth'
 import { Navbar } from '../components/Navbar'
 import { Avatar } from '../components/Avatar'
-import type { Jogo, Time, Palpite, Usuario, Fase, Config } from '../types'
+import type { Jogo, Time, Palpite, Usuario, Fase, Config, PalpiteEspecial, ResultadoEspecial } from '../types'
 
-const FASES: { id: Fase | 'todos'; label: string }[] = [
+type AbaId = Fase | 'todos' | 'especiais'
+
+const FASES: { id: AbaId; label: string }[] = [
   { id: 'todos', label: 'Todos' },
   { id: 'grupos', label: 'Grupos' },
+  { id: 'fase32', label: 'Segunda Fase' },
   { id: 'oitavas', label: 'Oitavas' },
   { id: 'quartas', label: 'Quartas' },
   { id: 'semi', label: 'Semis' },
   { id: 'terceiro', label: '3o Lugar' },
   { id: 'final', label: 'Final' },
+  { id: 'especiais', label: 'Especiais' },
 ]
 
 export function PalpitesGeral() {
@@ -22,10 +26,12 @@ export function PalpitesGeral() {
   const [jogos, setJogos] = useState<Jogo[]>([])
   const [times, setTimes] = useState<Map<string, Time>>(new Map())
   const [palpites, setPalpites] = useState<Palpite[]>([])
+  const [palpitesEspeciais, setPalpitesEspeciais] = useState<PalpiteEspecial[]>([])
+  const [resultadoEspecial, setResultadoEspecial] = useState<ResultadoEspecial | null>(null)
   const [usuarios, setUsuarios] = useState<Map<string, Usuario>>(new Map())
   const [config, setConfig] = useState<Config | null>(null)
   const [loading, setLoading] = useState(true)
-  const [faseAtiva, setFaseAtiva] = useState<Fase | 'todos'>('grupos')
+  const [faseAtiva, setFaseAtiva] = useState<AbaId>('grupos')
   const [usuarioFiltro, setUsuarioFiltro] = useState('')
   const [grupoFiltro, setGrupoFiltro] = useState('')
 
@@ -33,12 +39,17 @@ export function PalpitesGeral() {
 
   useEffect(() => {
     async function load() {
-      const [jogosSnap, timesSnap, usuariosSnap, configSnap] = await Promise.all([
+      const [jogosSnap, timesSnap, usuariosSnap, configSnap, resultadoEspecialSnap] = await Promise.all([
         getDocs(collection(db, 'jogos')),
         getDocs(collection(db, 'times')),
         getDocs(collection(db, 'usuarios')),
         getDoc(doc(db, 'config', 'geral')),
+        getDoc(doc(db, 'config', 'resultado_especial')),
       ])
+
+      if (resultadoEspecialSnap.exists()) {
+        setResultadoEspecial(resultadoEspecialSnap.data() as ResultadoEspecial)
+      }
 
       const jogosData = jogosSnap.docs.map(d => ({ id: d.id, ...d.data() } as Jogo))
       jogosData.sort((a, b) => a.dataHora.toMillis() - b.dataHora.toMillis())
@@ -98,6 +109,23 @@ export function PalpitesGeral() {
         }
 
         setPalpites(Array.from(palpitesMap.values()))
+
+        // Palpites especiais: regras permitem ler todos quando 'sempre' ou
+        // 'apos_prazo' (após prazo). Caso contrário, só o próprio.
+        const podeLerTodosEspeciais =
+          isAdmin ||
+          visibilidadeAtual === 'sempre' ||
+          (visibilidadeAtual === 'apos_prazo' && prazoJaExpirou)
+
+        if (podeLerTodosEspeciais) {
+          const especiaisSnap = await getDocs(collection(db, 'palpites_especiais'))
+          setPalpitesEspeciais(especiaisSnap.docs.map(d => ({ uid: d.id, ...d.data() } as PalpiteEspecial)))
+        } else {
+          const proprioSnap = await getDoc(doc(db, 'palpites_especiais', firebaseUser.uid))
+          if (proprioSnap.exists()) {
+            setPalpitesEspeciais([{ uid: firebaseUser.uid, ...proprioSnap.data() } as PalpiteEspecial])
+          }
+        }
       }
 
       setLoading(false)
@@ -180,6 +208,43 @@ export function PalpitesGeral() {
     return times.get(id)?.bandeira
   }
 
+  const palpiteEspecialMap = useMemo(() => {
+    const map = new Map<string, PalpiteEspecial>()
+    for (const pe of palpitesEspeciais) map.set(pe.uid, pe)
+    return map
+  }, [palpitesEspeciais])
+
+  function especialVisivel(uid: string): boolean {
+    if (uid === firebaseUser?.uid) return true
+    if (isAdmin) return true
+    switch (visibilidade) {
+      case 'sempre':
+        return true
+      case 'apos_prazo':
+        return prazoExpirado
+      case 'apos_jogo':
+      case 'nunca':
+      default:
+        return false
+    }
+  }
+
+  const COLUNAS_ESPECIAIS: { key: keyof Pick<PalpiteEspecial, 'campeao' | 'vice' | 'terceiro' | 'quarto' | 'paisArtilheiro'>; label: string; icone: string }[] = [
+    { key: 'campeao', label: 'Campeão', icone: '🏆' },
+    { key: 'vice', label: 'Vice', icone: '🥈' },
+    { key: 'terceiro', label: '3º', icone: '🥉' },
+    { key: 'quarto', label: '4º', icone: '4' },
+    { key: 'paisArtilheiro', label: 'Artilheiro', icone: '⚽' },
+  ]
+
+  function timeAcerta(coluna: typeof COLUNAS_ESPECIAIS[number]['key'], timeId: string): boolean {
+    if (!resultadoEspecial) return false
+    if (coluna === 'paisArtilheiro') {
+      return (resultadoEspecial.paisesArtilheiros ?? []).includes(timeId)
+    }
+    return resultadoEspecial[coluna] === timeId
+  }
+
   // Mensagem sobre visibilidade
   const visibilidadeLabel: Record<string, string> = {
     sempre: 'Todos os palpites estão visíveis.',
@@ -250,7 +315,89 @@ export function PalpitesGeral() {
           />
         </div>
 
-        {/* Tabela */}
+        {/* Tabela de Especiais (na aba Especiais) */}
+        {faseAtiva === 'especiais' && (
+          <div className="bg-white rounded-lg shadow overflow-auto max-h-[70vh]">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 sticky top-0 z-10">
+                <tr>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 sticky left-0 bg-gray-50 min-w-[140px]">
+                    Participante
+                  </th>
+                  {COLUNAS_ESPECIAIS.map(col => (
+                    <th key={col.key} className="px-3 py-2 text-center text-xs font-medium text-gray-600 min-w-[120px]">
+                      <div className="flex flex-col items-center gap-0.5">
+                        <span className="text-base">{col.icone}</span>
+                        <span>{col.label}</span>
+                      </div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {usuariosFiltrados.map(u => {
+                  const ehEu = u.uid === firebaseUser?.uid
+                  const pe = palpiteEspecialMap.get(u.uid)
+                  const visivel = especialVisivel(u.uid)
+                  return (
+                    <tr key={u.uid} className={`hover:bg-blue-50/50 ${ehEu ? 'bg-blue-50/30' : ''}`}>
+                      <td className={`px-3 py-2 font-medium sticky left-0 whitespace-nowrap ${ehEu ? 'text-blue-700 bg-blue-50/30' : 'text-gray-800 bg-white'}`}>
+                        <div className="flex items-center gap-2">
+                          <Avatar
+                            src={u.fotoURL ?? null}
+                            nome={u.apelido || u.nome}
+                            uid={u.uid}
+                            size="sm"
+                            ring={false}
+                          />
+                          <span>{u.apelido || u.nome || 'Sem nome'}</span>
+                          {ehEu && <span className="text-[10px] text-blue-400">(eu)</span>}
+                        </div>
+                      </td>
+                      {COLUNAS_ESPECIAIS.map(col => {
+                        if (!pe) {
+                          return <td key={col.key} className="px-3 py-2 text-center text-gray-300">-</td>
+                        }
+                        if (!visivel) {
+                          return (
+                            <td key={col.key} className="px-3 py-2 text-center text-gray-300">
+                              <span title="Palpite oculto">***</span>
+                            </td>
+                          )
+                        }
+                        const timeId = pe[col.key]
+                        if (!timeId) {
+                          return <td key={col.key} className="px-3 py-2 text-center text-gray-300">-</td>
+                        }
+                        const acerto = resultadoEspecial ? timeAcerta(col.key, timeId) : false
+                        const corClasse = acerto
+                          ? 'text-green-700 bg-green-50 font-bold'
+                          : (resultadoEspecial ? 'text-red-400' : 'text-gray-700')
+                        return (
+                          <td key={col.key} className={`px-3 py-2 text-center text-xs rounded ${corClasse}`}>
+                            <div className="flex items-center justify-center gap-1.5">
+                              {bandeiraUrl(timeId) && (
+                                <img src={bandeiraUrl(timeId)!} alt="" className="w-4 h-3 object-cover rounded" />
+                              )}
+                              <span className="font-mono">{sigla(timeId)}</span>
+                            </div>
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+
+            {usuariosFiltrados.length === 0 && (
+              <p className="text-center text-gray-400 py-8">Nenhum participante encontrado.</p>
+            )}
+          </div>
+        )}
+
+        {/* Tabela de jogos (todas as abas exceto Especiais) */}
+        {faseAtiva !== 'especiais' && (
         <div className="bg-white rounded-lg shadow overflow-auto max-h-[70vh]">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 sticky top-0 z-10">
@@ -356,9 +503,10 @@ export function PalpitesGeral() {
             <p className="text-center text-gray-400 py-8">Nenhum participante encontrado.</p>
           )}
         </div>
+        )}
 
         {/* Legenda */}
-        {jogosFiltrados.some(j => j.encerrado) && (
+        {faseAtiva !== 'especiais' && jogosFiltrados.some(j => j.encerrado) && (
           <div className="mt-3 flex flex-wrap gap-3 text-xs text-gray-500">
             <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-green-50 border border-green-200" /> Placar exato</span>
             <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-blue-50 border border-blue-200" /> Placar de 1 time</span>

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import { NavLink, Routes, Route, Navigate } from 'react-router-dom'
 import { Navbar } from '../../components/Navbar'
 import { Dashboard } from './Dashboard'
+import { Auditoria } from './Auditoria'
 import { GerenciarTimes } from './GerenciarTimes'
 import { GerenciarJogos } from './GerenciarJogos'
 import { InserirResultados } from './InserirResultados'
@@ -19,6 +20,7 @@ const NAV_LINKS = [
   { to: '/admin/palpites', label: 'Palpites' },
   { to: '/admin/convites', label: 'Convites' },
   { to: '/admin/usuarios', label: 'Usuários' },
+  { to: '/admin/auditoria', label: 'Auditoria' },
   { to: '/admin/config', label: 'Configurações' },
 ]
 
@@ -58,6 +60,7 @@ export function AdminDashboard() {
           <Route path="palpites" element={<VerPalpites />} />
           <Route path="convites" element={<GerenciarConvites />} />
           <Route path="usuarios" element={<GerenciarUsuarios />} />
+          <Route path="auditoria" element={<Auditoria />} />
           <Route path="config" element={<Configuracoes />} />
         </Routes>
       </main>

--- a/src/pages/admin/Auditoria.tsx
+++ b/src/pages/admin/Auditoria.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useMemo, useState } from 'react'
+import { collection, getDocs, query, where, orderBy, limit, Timestamp } from 'firebase/firestore'
+import { db } from '../../config/firebase'
+import { Avatar } from '../../components/Avatar'
+import type { Usuario } from '../../types'
+
+interface AuditDoc {
+  id: string
+  eventType: string
+  targetUid: string | null
+  targetPath: string
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+  changedFields: string[]
+  at: Timestamp
+}
+
+const TIPOS_EVENTO = [
+  { value: '', label: 'Todos os tipos' },
+  { value: 'palpite_create', label: 'Palpite criado' },
+  { value: 'palpite_update', label: 'Palpite atualizado' },
+  { value: 'palpite_delete', label: 'Palpite excluído' },
+  { value: 'palpite_especial_create', label: 'Palpite especial criado' },
+  { value: 'palpite_especial_update', label: 'Palpite especial atualizado' },
+  { value: 'palpite_especial_delete', label: 'Palpite especial excluído' },
+  { value: 'usuario_create', label: 'Usuário criado' },
+  { value: 'usuario_update', label: 'Usuário atualizado' },
+  { value: 'usuario_delete', label: 'Usuário excluído' },
+]
+
+const PAGE_SIZE = 100
+
+function formatarTimestamp(t: Timestamp): string {
+  return t.toDate().toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'medium' })
+}
+
+function formatarValor(v: unknown): string {
+  if (v == null) return '—'
+  if (v instanceof Timestamp) return v.toDate().toLocaleString('pt-BR')
+  if (typeof v === 'object') return JSON.stringify(v)
+  return String(v)
+}
+
+function CorEvento({ tipo }: { tipo: string }) {
+  const map: Record<string, string> = {
+    palpite_create: 'bg-green-100 text-green-700',
+    palpite_update: 'bg-blue-100 text-blue-700',
+    palpite_delete: 'bg-red-100 text-red-700',
+    palpite_especial_create: 'bg-emerald-100 text-emerald-700',
+    palpite_especial_update: 'bg-cyan-100 text-cyan-700',
+    palpite_especial_delete: 'bg-rose-100 text-rose-700',
+    usuario_create: 'bg-violet-100 text-violet-700',
+    usuario_update: 'bg-amber-100 text-amber-700',
+    usuario_delete: 'bg-pink-100 text-pink-700',
+  }
+  const cls = map[tipo] ?? 'bg-gray-100 text-gray-700'
+  return <span className={`text-[11px] font-semibold rounded-full px-2 py-0.5 ${cls}`}>{tipo}</span>
+}
+
+function Diff({ before, after, changedFields }: { before: AuditDoc['before']; after: AuditDoc['after']; changedFields: string[] }) {
+  if (changedFields.length === 0) return null
+  return (
+    <div className="mt-2 text-xs space-y-1">
+      {changedFields.map(field => {
+        const b = before?.[field]
+        const a = after?.[field]
+        return (
+          <div key={field} className="flex flex-wrap gap-1 items-center">
+            <span className="font-semibold text-gray-600">{field}:</span>
+            <span className="line-through text-gray-400">{formatarValor(b)}</span>
+            <span className="text-gray-400">→</span>
+            <span className="text-gray-800">{formatarValor(a)}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function Auditoria() {
+  const [logs, setLogs] = useState<AuditDoc[]>([])
+  const [usuarios, setUsuarios] = useState<Map<string, Usuario>>(new Map())
+  const [loading, setLoading] = useState(true)
+  const [filtroTipo, setFiltroTipo] = useState('')
+  const [filtroUid, setFiltroUid] = useState('')
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+
+      const usuariosSnap = await getDocs(collection(db, 'usuarios'))
+      const usMap = new Map<string, Usuario>()
+      usuariosSnap.docs.forEach(d => usMap.set(d.id, { uid: d.id, ...d.data() } as Usuario))
+      setUsuarios(usMap)
+
+      const constraints = []
+      if (filtroTipo) constraints.push(where('eventType', '==', filtroTipo))
+      if (filtroUid) constraints.push(where('targetUid', '==', filtroUid))
+      constraints.push(orderBy('at', 'desc'))
+      constraints.push(limit(PAGE_SIZE))
+
+      const q = query(collection(db, 'audit_log'), ...constraints)
+      const snap = await getDocs(q)
+      setLogs(snap.docs.map(d => ({ id: d.id, ...d.data() } as AuditDoc)))
+      setLoading(false)
+    }
+    load()
+  }, [filtroTipo, filtroUid])
+
+  const usuariosOrdenados = useMemo(() => {
+    return Array.from(usuarios.values()).sort((a, b) =>
+      (a.apelido || a.nome || '').localeCompare(b.apelido || b.nome || ''))
+  }, [usuarios])
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6">
+      <h2 className="text-xl font-bold text-gray-800 mb-4">Auditoria</h2>
+
+      <div className="bg-white rounded-xl shadow border border-gray-100 p-4 mb-4 grid sm:grid-cols-2 gap-3">
+        <div>
+          <label className="block text-xs font-semibold text-gray-600 mb-1">Tipo de evento</label>
+          <select
+            value={filtroTipo}
+            onChange={e => setFiltroTipo(e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
+          >
+            {TIPOS_EVENTO.map(t => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-gray-600 mb-1">Usuário afetado</label>
+          <select
+            value={filtroUid}
+            onChange={e => setFiltroUid(e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
+          >
+            <option value="">Todos os usuários</option>
+            {usuariosOrdenados.map(u => (
+              <option key={u.uid} value={u.uid}>{u.apelido || u.nome} ({u.email})</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {loading && <p className="text-gray-500 text-sm">Carregando...</p>}
+
+      {!loading && logs.length === 0 && (
+        <p className="text-gray-500 text-sm bg-white rounded-xl border border-gray-100 p-6 text-center">
+          Nenhum evento encontrado para os filtros aplicados.
+        </p>
+      )}
+
+      {!loading && logs.length > 0 && (
+        <div className="bg-white rounded-xl shadow border border-gray-100 divide-y divide-gray-100">
+          {logs.map(log => {
+            const usuario = log.targetUid ? usuarios.get(log.targetUid) : null
+            return (
+              <div key={log.id} className="p-4">
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                  <div className="flex items-center gap-3 min-w-0">
+                    {usuario && (
+                      <Avatar
+                        src={usuario.fotoURL ?? null}
+                        nome={usuario.apelido || usuario.nome}
+                        uid={usuario.uid}
+                        size="sm"
+                        ring={false}
+                      />
+                    )}
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-800 truncate">
+                        {usuario ? (usuario.apelido || usuario.nome) : (log.targetUid ?? '—')}
+                      </p>
+                      <p className="text-[11px] text-gray-500 truncate">{log.targetPath}</p>
+                    </div>
+                  </div>
+                  <div className="text-right shrink-0">
+                    <CorEvento tipo={log.eventType} />
+                    <p className="text-[11px] text-gray-500 mt-1">{formatarTimestamp(log.at)}</p>
+                  </div>
+                </div>
+                <Diff before={log.before} after={log.after} changedFields={log.changedFields} />
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <p className="text-[11px] text-gray-400 mt-3 text-center">
+        Mostrando os últimos {PAGE_SIZE} eventos. Para histórico completo, consulte BigQuery ou Firestore Console.
+      </p>
+    </div>
+  )
+}

--- a/src/pages/admin/Configuracoes.tsx
+++ b/src/pages/admin/Configuracoes.tsx
@@ -58,6 +58,8 @@ export function Configuracoes() {
   const [salvo, setSalvo] = useState(false)
   const [recalculando, setRecalculando] = useState(false)
   const [rankingMsg, setRankingMsg] = useState<{ tipo: 'sucesso' | 'erro'; texto: string } | null>(null)
+  const [resolvendoMataMata, setResolvendoMataMata] = useState(false)
+  const [mataMataMsg, setMataMataMsg] = useState<{ tipo: 'sucesso' | 'erro' | 'aviso'; texto: string } | null>(null)
 
   useEffect(() => {
     async function carregar() {
@@ -116,6 +118,28 @@ export function Configuracoes() {
     setLoading(false)
     setSalvo(true)
     setTimeout(() => setSalvo(false), 3000)
+  }
+
+  async function handleResolverMataMata() {
+    if (!confirm('Resolver mata-mata: vai preencher os times dos jogos do mata-mata baseado nos resultados reais. Idempotente — pode rodar mais de uma vez.')) return
+    setMataMataMsg(null)
+    setResolvendoMataMata(true)
+    try {
+      const fn = httpsCallable<unknown, { ok: boolean; motivo?: string; atualizados?: number; pendentes?: number; gruposEncerrados?: number; gruposTotal?: number }>(functions, 'resolverMataMata')
+      const result = await fn({})
+      const r = result.data
+      if (!r.ok && r.motivo === 'fase_grupos_incompleta') {
+        setMataMataMsg({ tipo: 'aviso', texto: `Fase de grupos ainda nao terminou (${r.gruposEncerrados}/${r.gruposTotal} jogos com resultado).` })
+      } else if (r.ok) {
+        setMataMataMsg({ tipo: 'sucesso', texto: `Mata-mata resolvido. ${r.atualizados} jogo(s) atualizado(s). ${r.pendentes} ainda dependem de jogos posteriores.` })
+      } else {
+        setMataMataMsg({ tipo: 'erro', texto: 'Falha ao resolver mata-mata.' })
+      }
+    } catch {
+      setMataMataMsg({ tipo: 'erro', texto: 'Erro ao chamar a funcao. Veja logs.' })
+    } finally {
+      setResolvendoMataMata(false)
+    }
   }
 
   async function handleRecalcularRanking() {
@@ -356,6 +380,30 @@ export function Configuracoes() {
           className="bg-amber-600 text-white px-5 py-2 rounded hover:bg-amber-700 disabled:opacity-50 transition-colors"
         >
           {recalculando ? 'Recalculando...' : 'Recalcular Ranking'}
+        </button>
+      </div>
+
+      {/* Resolver Mata-mata */}
+      <div className="bg-white shadow rounded-lg p-6 mt-6">
+        <h2 className="text-lg font-semibold mb-2">Resolver Mata-mata</h2>
+        <p className="text-sm text-gray-600 mb-4">
+          Apos o termino da fase de grupos (e a cada nova fase encerrada), preenche os times dos jogos do mata-mata
+          (1A, 2B, 3o melhor, vencedor de jogo X, etc.) baseado nos resultados reais. Idempotente.
+        </p>
+
+        {mataMataMsg && (
+          <p className={`text-sm mb-4 ${mataMataMsg.tipo === 'sucesso' ? 'text-green-600' : mataMataMsg.tipo === 'aviso' ? 'text-amber-600' : 'text-red-600'}`}>
+            {mataMataMsg.texto}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={handleResolverMataMata}
+          disabled={resolvendoMataMata}
+          className="bg-purple-600 text-white px-5 py-2 rounded hover:bg-purple-700 disabled:opacity-50 transition-colors"
+        >
+          {resolvendoMataMata ? 'Resolvendo...' : 'Resolver Mata-mata'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
Itens 1 e 2 do plano.

Item 1 — /admin/auditoria: lista eventos do audit_log com filtros por tipo e por usuario, com diff de campos alterados.

Item 2 — Cloud Function callable resolverMataMata: chamada por admin via /admin/config, preenche os times do mata-mata baseado em resultados reais. Suporta labels 1A/2B/3A/3ABCDF/W73/RU101/L99. Idempotente. Roda em qualquer fase, resolvendo o que ja eh possivel.

Indexes compostos para audit_log adicionados a firestore.indexes.json.

Item 3 (resgate do stash) deixado para PR separado.