### PR TITLE
feat: resgate cirurgico do stash (UX resultados, ver palpites, vinculo telefone)

### DIFF
--- a/src/pages/PalpitesGeral.tsx
+++ b/src/pages/PalpitesGeral.tsx
@@ -264,6 +264,86 @@ export function PalpitesGeral() {
     )
   }
 
+  const tabelaEspeciais = (
+    <div className="bg-white rounded-lg shadow overflow-auto max-h-[70vh]">
+      <table className="w-full text-sm">
+        <thead className="bg-gray-50 sticky top-0 z-10">
+          <tr>
+            <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 sticky left-0 bg-gray-50 min-w-[140px]">
+              Participante
+            </th>
+            {COLUNAS_ESPECIAIS.map(col => (
+              <th key={col.key} className="px-3 py-2 text-center text-xs font-medium text-gray-600 min-w-[120px]">
+                <div className="flex flex-col items-center gap-0.5">
+                  <span className="text-base">{col.icone}</span>
+                  <span>{col.label}</span>
+                </div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-50">
+          {usuariosFiltrados.map(u => {
+            const ehEu = u.uid === firebaseUser?.uid
+            const pe = palpiteEspecialMap.get(u.uid)
+            const visivel = especialVisivel(u.uid)
+            return (
+              <tr key={u.uid} className={`hover:bg-blue-50/50 ${ehEu ? 'bg-blue-50/30' : ''}`}>
+                <td className={`px-3 py-2 font-medium sticky left-0 whitespace-nowrap ${ehEu ? 'text-blue-700 bg-blue-50/30' : 'text-gray-800 bg-white'}`}>
+                  <div className="flex items-center gap-2">
+                    <Avatar
+                      src={u.fotoURL ?? null}
+                      nome={u.apelido || u.nome}
+                      uid={u.uid}
+                      size="sm"
+                      ring={false}
+                    />
+                    <span>{u.apelido || u.nome || 'Sem nome'}</span>
+                    {ehEu && <span className="text-[10px] text-blue-400">(eu)</span>}
+                  </div>
+                </td>
+                {COLUNAS_ESPECIAIS.map(col => {
+                  if (!pe) {
+                    return <td key={col.key} className="px-3 py-2 text-center text-gray-300">-</td>
+                  }
+                  if (!visivel) {
+                    return (
+                      <td key={col.key} className="px-3 py-2 text-center text-gray-300">
+                        <span title="Palpite oculto">***</span>
+                      </td>
+                    )
+                  }
+                  const timeId = pe[col.key]
+                  if (!timeId) {
+                    return <td key={col.key} className="px-3 py-2 text-center text-gray-300">-</td>
+                  }
+                  const acerto = resultadoEspecial ? timeAcerta(col.key, timeId) : false
+                  const corClasse = acerto
+                    ? 'text-green-700 bg-green-50 font-bold'
+                    : (resultadoEspecial ? 'text-red-400' : 'text-gray-700')
+                  return (
+                    <td key={col.key} className={`px-3 py-2 text-center text-xs rounded ${corClasse}`}>
+                      <div className="flex items-center justify-center gap-1.5">
+                        {bandeiraUrl(timeId) && (
+                          <img src={bandeiraUrl(timeId)!} alt="" className="w-4 h-3 object-cover rounded" />
+                        )}
+                        <span className="font-mono">{sigla(timeId)}</span>
+                      </div>
+                    </td>
+                  )
+                })}
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      {usuariosFiltrados.length === 0 && (
+        <p className="text-center text-gray-400 py-8">Nenhum participante encontrado.</p>
+      )}
+    </div>
+  )
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Navbar />
@@ -316,85 +396,7 @@ export function PalpitesGeral() {
         </div>
 
         {/* Tabela de Especiais (na aba Especiais) */}
-        {faseAtiva === 'especiais' && (
-          <div className="bg-white rounded-lg shadow overflow-auto max-h-[70vh]">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50 sticky top-0 z-10">
-                <tr>
-                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 sticky left-0 bg-gray-50 min-w-[140px]">
-                    Participante
-                  </th>
-                  {COLUNAS_ESPECIAIS.map(col => (
-                    <th key={col.key} className="px-3 py-2 text-center text-xs font-medium text-gray-600 min-w-[120px]">
-                      <div className="flex flex-col items-center gap-0.5">
-                        <span className="text-base">{col.icone}</span>
-                        <span>{col.label}</span>
-                      </div>
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-50">
-                {usuariosFiltrados.map(u => {
-                  const ehEu = u.uid === firebaseUser?.uid
-                  const pe = palpiteEspecialMap.get(u.uid)
-                  const visivel = especialVisivel(u.uid)
-                  return (
-                    <tr key={u.uid} className={`hover:bg-blue-50/50 ${ehEu ? 'bg-blue-50/30' : ''}`}>
-                      <td className={`px-3 py-2 font-medium sticky left-0 whitespace-nowrap ${ehEu ? 'text-blue-700 bg-blue-50/30' : 'text-gray-800 bg-white'}`}>
-                        <div className="flex items-center gap-2">
-                          <Avatar
-                            src={u.fotoURL ?? null}
-                            nome={u.apelido || u.nome}
-                            uid={u.uid}
-                            size="sm"
-                            ring={false}
-                          />
-                          <span>{u.apelido || u.nome || 'Sem nome'}</span>
-                          {ehEu && <span className="text-[10px] text-blue-400">(eu)</span>}
-                        </div>
-                      </td>
-                      {COLUNAS_ESPECIAIS.map(col => {
-                        if (!pe) {
-                          return <td key={col.key} className="px-3 py-2 text-center text-gray-300">-</td>
-                        }
-                        if (!visivel) {
-                          return (
-                            <td key={col.key} className="px-3 py-2 text-center text-gray-300">
-                              <span title="Palpite oculto">***</span>
-                            </td>
-                          )
-                        }
-                        const timeId = pe[col.key]
-                        if (!timeId) {
-                          return <td key={col.key} className="px-3 py-2 text-center text-gray-300">-</td>
-                        }
-                        const acerto = resultadoEspecial ? timeAcerta(col.key, timeId) : false
-                        const corClasse = acerto
-                          ? 'text-green-700 bg-green-50 font-bold'
-                          : (resultadoEspecial ? 'text-red-400' : 'text-gray-700')
-                        return (
-                          <td key={col.key} className={`px-3 py-2 text-center text-xs rounded ${corClasse}`}>
-                            <div className="flex items-center justify-center gap-1.5">
-                              {bandeiraUrl(timeId) && (
-                                <img src={bandeiraUrl(timeId)!} alt="" className="w-4 h-3 object-cover rounded" />
-                              )}
-                              <span className="font-mono">{sigla(timeId)}</span>
-                            </div>
-                          </td>
-                        )
-                      })}
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-
-            {usuariosFiltrados.length === 0 && (
-              <p className="text-center text-gray-400 py-8">Nenhum participante encontrado.</p>
-            )}
-          </div>
-        )}
+        {faseAtiva === 'especiais' && tabelaEspeciais}
 
         {/* Tabela de jogos (todas as abas exceto Especiais) */}
         {faseAtiva !== 'especiais' && (
@@ -503,6 +505,14 @@ export function PalpitesGeral() {
             <p className="text-center text-gray-400 py-8">Nenhum participante encontrado.</p>
           )}
         </div>
+        )}
+
+        {/* Especiais ao final da aba Todos */}
+        {faseAtiva === 'todos' && (
+          <div className="mt-6">
+            <h2 className="text-lg font-bold text-gray-800 mb-2">Palpites Especiais</h2>
+            {tabelaEspeciais}
+          </div>
         )}
 
         {/* Legenda */}

--- a/src/pages/VerificarVinculo.tsx
+++ b/src/pages/VerificarVinculo.tsx
@@ -10,6 +10,7 @@ import { doc, updateDoc } from 'firebase/firestore'
 import { auth, db } from '../config/firebase'
 import { useAuth } from '../hooks/useAuth'
 import { Navbar } from '../components/Navbar'
+import { PhoneInput } from '../components/PhoneInput'
 
 type PhoneStep = 'input' | 'confirm'
 
@@ -26,7 +27,7 @@ export function VerificarVinculo() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
-  const [verificationId, setVerificationId] = useState('')
+  const verificationIdRef = useRef<string | null>(null)
   const recaptchaRef = useRef<RecaptchaVerifier | null>(null)
   const recaptchaContainerRef = useRef<HTMLDivElement>(null)
 
@@ -42,8 +43,19 @@ export function VerificarVinculo() {
     }
   }, [])
 
+  const resetRecaptcha = () => {
+    recaptchaRef.current?.clear()
+    recaptchaRef.current = null
+    if (recaptchaContainerRef.current) {
+      recaptchaContainerRef.current.innerHTML = ''
+    }
+  }
+
   const ensureRecaptcha = () => {
-    if (!recaptchaRef.current && recaptchaContainerRef.current) {
+    if (recaptchaRef.current) {
+      resetRecaptcha()
+    }
+    if (recaptchaContainerRef.current) {
       recaptchaRef.current = new RecaptchaVerifier(auth, recaptchaContainerRef.current, {
         size: 'invisible',
       })
@@ -76,13 +88,13 @@ export function VerificarVinculo() {
     try {
       ensureRecaptcha()
       const provider = new PhoneAuthProvider(auth)
-      const vId = await provider.verifyPhoneNumber(phone, recaptchaRef.current!)
-      setVerificationId(vId)
+      const verificationId = await provider.verifyPhoneNumber(phone, recaptchaRef.current!)
+      verificationIdRef.current = verificationId
       setPhoneStep('confirm')
     } catch (err: unknown) {
+      console.error('verifyPhoneNumber error:', JSON.stringify(err, Object.getOwnPropertyNames(err as object)))
       setError(getErrorMessage(err))
-      recaptchaRef.current?.clear()
-      recaptchaRef.current = null
+      resetRecaptcha()
     } finally {
       setLoading(false)
     }
@@ -90,11 +102,11 @@ export function VerificarVinculo() {
 
   const handleConfirmCode = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!firebaseUser) return
+    if (!firebaseUser || !verificationIdRef.current) return
     setError('')
     setLoading(true)
     try {
-      const credential = PhoneAuthProvider.credential(verificationId, smsCode)
+      const credential = PhoneAuthProvider.credential(verificationIdRef.current, smsCode)
       await linkWithCredential(firebaseUser, credential)
       await updateDoc(doc(db, 'usuarios', firebaseUser.uid), { telefone: phone })
       await refreshUsuario()
@@ -160,15 +172,12 @@ export function VerificarVinculo() {
                 <form onSubmit={handleSendSms} className="space-y-4">
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Telefone (com DDI, ex: +5511999999999)
+                      Telefone
                     </label>
-                    <input
-                      type="tel"
-                      required
+                    <PhoneInput
                       value={phone}
-                      onChange={(e) => setPhone(e.target.value)}
-                      className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                      placeholder="+5511999999999"
+                      onChange={setPhone}
+                      required
                     />
                   </div>
                   {error && <p className="text-sm text-red-600">{error}</p>}

--- a/src/pages/admin/InserirResultados.tsx
+++ b/src/pages/admin/InserirResultados.tsx
@@ -272,23 +272,59 @@ export function InserirResultados() {
           {/* Inputs de placar */}
           {editable ? (
             <div className="flex items-center gap-2">
-              <input
-                type="number"
-                min={0}
-                value={form.golsCasa}
-                onChange={(e) => setResultado(jogo.id, 'golsCasa', e.target.value)}
-                className="border rounded px-2 py-1 w-14 text-center text-lg font-bold focus:outline-none focus:ring-2 focus:ring-blue-500"
-                placeholder="-"
-              />
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => setResultado(jogo.id, 'golsCasa', String(Math.max(0, (Number(form.golsCasa) || 0) - 1)))}
+                  className="w-7 h-7 flex items-center justify-center rounded bg-gray-200 text-gray-600 hover:bg-gray-300 text-sm font-bold transition-colors"
+                  aria-label="Diminuir gols casa"
+                >
+                  -
+                </button>
+                <input
+                  type="number"
+                  min={0}
+                  value={form.golsCasa}
+                  onChange={(e) => setResultado(jogo.id, 'golsCasa', e.target.value)}
+                  className="border rounded px-2 py-1 w-14 text-center text-lg font-bold focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="-"
+                />
+                <button
+                  type="button"
+                  onClick={() => setResultado(jogo.id, 'golsCasa', String((Number(form.golsCasa) || 0) + 1))}
+                  className="w-7 h-7 flex items-center justify-center rounded bg-gray-200 text-gray-600 hover:bg-gray-300 text-sm font-bold transition-colors"
+                  aria-label="Aumentar gols casa"
+                >
+                  +
+                </button>
+              </div>
               <span className="font-bold text-gray-400">x</span>
-              <input
-                type="number"
-                min={0}
-                value={form.golsVisitante}
-                onChange={(e) => setResultado(jogo.id, 'golsVisitante', e.target.value)}
-                className="border rounded px-2 py-1 w-14 text-center text-lg font-bold focus:outline-none focus:ring-2 focus:ring-blue-500"
-                placeholder="-"
-              />
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => setResultado(jogo.id, 'golsVisitante', String(Math.max(0, (Number(form.golsVisitante) || 0) - 1)))}
+                  className="w-7 h-7 flex items-center justify-center rounded bg-gray-200 text-gray-600 hover:bg-gray-300 text-sm font-bold transition-colors"
+                  aria-label="Diminuir gols visitante"
+                >
+                  -
+                </button>
+                <input
+                  type="number"
+                  min={0}
+                  value={form.golsVisitante}
+                  onChange={(e) => setResultado(jogo.id, 'golsVisitante', e.target.value)}
+                  className="border rounded px-2 py-1 w-14 text-center text-lg font-bold focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="-"
+                />
+                <button
+                  type="button"
+                  onClick={() => setResultado(jogo.id, 'golsVisitante', String((Number(form.golsVisitante) || 0) + 1))}
+                  className="w-7 h-7 flex items-center justify-center rounded bg-gray-200 text-gray-600 hover:bg-gray-300 text-sm font-bold transition-colors"
+                  aria-label="Aumentar gols visitante"
+                >
+                  +
+                </button>
+              </div>
             </div>
           ) : (
             <div className="flex items-center gap-2">

--- a/src/pages/admin/VerPalpites.tsx
+++ b/src/pages/admin/VerPalpites.tsx
@@ -6,6 +6,7 @@ import type { Jogo, Time, Palpite, Usuario, Fase } from '../../types'
 const FASES: { id: Fase | 'todos'; label: string }[] = [
   { id: 'todos', label: 'Todos' },
   { id: 'grupos', label: 'Grupos' },
+  { id: 'fase32', label: 'Segunda Fase' },
   { id: 'oitavas', label: 'Oitavas' },
   { id: 'quartas', label: 'Quartas' },
   { id: 'semi', label: 'Semis' },
@@ -57,6 +58,16 @@ export function VerPalpites() {
     )
   }, [usuarios])
 
+  const FASE_LABELS: Record<string, string> = {
+    grupos: 'Grupos',
+    fase32: 'Segunda Fase',
+    oitavas: 'Oitavas',
+    quartas: 'Quartas',
+    semi: 'Semis',
+    terceiro: '3o Lugar',
+    final: 'Final',
+  }
+
   const jogosFiltrados = useMemo(() => {
     let lista = jogos
     if (faseAtiva !== 'todos') {
@@ -67,6 +78,19 @@ export function VerPalpites() {
     }
     return lista
   }, [jogos, faseAtiva, grupoFiltro])
+
+  const faseSpans = useMemo(() => {
+    const spans: { fase: string; label: string; count: number }[] = []
+    for (const jogo of jogosFiltrados) {
+      const last = spans[spans.length - 1]
+      if (last && last.fase === jogo.fase) {
+        last.count++
+      } else {
+        spans.push({ fase: jogo.fase, label: FASE_LABELS[jogo.fase] ?? jogo.fase, count: 1 })
+      }
+    }
+    return spans
+  }, [jogosFiltrados])
 
   const usuariosFiltrados = useMemo(() => {
     if (!usuarioFiltro) return listaUsuarios
@@ -93,8 +117,8 @@ export function VerPalpites() {
     return Array.from(grupoSet).sort()
   }, [jogos])
 
-  function sigla(id: string): string {
-    return times.get(id)?.sigla ?? '?'
+  function nome(id: string): string | undefined {
+    return times.get(id)?.nome
   }
 
   function bandeira(id: string): string | undefined {
@@ -151,26 +175,51 @@ export function VerPalpites() {
       <div className="bg-white rounded-lg shadow overflow-auto max-h-[70vh]">
         <table className="w-full text-sm">
           <thead className="bg-gray-50 sticky top-0 z-10">
+            {/* Linha de fases */}
+            {faseAtiva === 'todos' && faseSpans.length > 1 && (
+              <tr>
+                <th className="sticky left-0 bg-gray-50" />
+                {faseSpans.map((span, i) => (
+                  <th
+                    key={`fase-${i}`}
+                    colSpan={span.count}
+                    className="px-1 py-1 text-center text-[10px] font-bold text-white bg-blue-700 border-l border-blue-600 first:border-l-0"
+                  >
+                    {span.label}
+                  </th>
+                ))}
+              </tr>
+            )}
+            {/* Linha de jogos */}
             <tr>
               <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 sticky left-0 bg-gray-50 min-w-[120px]">
                 Participante
               </th>
               {jogosFiltrados.map(jogo => (
-                <th key={jogo.id} className="px-2 py-2 text-center min-w-[80px]">
-                  <div className="flex flex-col items-center gap-0.5">
-                    <div className="flex items-center gap-1">
-                      {bandeira(jogo.timeCasa) && (
-                        <img src={bandeira(jogo.timeCasa)!} alt="" className="w-4 h-3 object-cover rounded" />
-                      )}
-                      <span className="text-xs font-medium text-gray-600">{sigla(jogo.timeCasa)}</span>
-                    </div>
-                    <span className="text-[10px] text-gray-400">vs</span>
-                    <div className="flex items-center gap-1">
-                      {bandeira(jogo.timeVisitante) && (
-                        <img src={bandeira(jogo.timeVisitante)!} alt="" className="w-4 h-3 object-cover rounded" />
-                      )}
-                      <span className="text-xs font-medium text-gray-600">{sigla(jogo.timeVisitante)}</span>
-                    </div>
+                <th key={jogo.id} className="px-1 py-2 text-center w-[90px] min-w-[90px] max-w-[90px] align-top">
+                  <div className="flex flex-col items-center h-full">
+                    <span className="text-[9px] font-bold text-blue-500 mb-1">Jogo {jogo.numero}</span>
+                    {jogo.timeCasa ? (
+                      <div className="flex items-center gap-1 justify-center">
+                        {bandeira(jogo.timeCasa) && (
+                          <img src={bandeira(jogo.timeCasa)!} alt="" className="w-4 h-3 object-cover rounded shrink-0" />
+                        )}
+                        <span className="text-[10px] font-medium text-gray-600 truncate max-w-[65px]" title={nome(jogo.timeCasa)}>{nome(jogo.timeCasa)}</span>
+                      </div>
+                    ) : (
+                      <span className="text-[9px] text-gray-400 italic">A definir</span>
+                    )}
+                    <span className="text-[9px] text-gray-400 leading-tight">vs</span>
+                    {jogo.timeVisitante ? (
+                      <div className="flex items-center gap-1 justify-center">
+                        {bandeira(jogo.timeVisitante) && (
+                          <img src={bandeira(jogo.timeVisitante)!} alt="" className="w-4 h-3 object-cover rounded shrink-0" />
+                        )}
+                        <span className="text-[10px] font-medium text-gray-600 truncate max-w-[65px]" title={nome(jogo.timeVisitante)}>{nome(jogo.timeVisitante)}</span>
+                      </div>
+                    ) : (
+                      <span className="text-[9px] text-gray-400 italic">A definir</span>
+                    )}
                     {jogo.encerrado && jogo.resultado && (
                       <span className="text-[10px] font-bold text-green-600 mt-0.5">
                         {jogo.resultado.golsCasa}x{jogo.resultado.golsVisitante}
@@ -197,22 +246,24 @@ export function VerPalpites() {
                     )
                   }
 
-                  // Verificar se acertou algo
+                  // Cor por acerto conforme regulamento
                   let corClasse = 'text-gray-700'
                   if (jogo.encerrado && jogo.resultado) {
                     const r = jogo.resultado
-                    if (p.golsCasa === r.golsCasa && p.golsVisitante === r.golsVisitante) {
-                      corClasse = 'text-green-700 bg-green-50 font-bold'
-                    } else if (p.golsCasa === r.golsCasa || p.golsVisitante === r.golsVisitante) {
-                      corClasse = 'text-blue-700 bg-blue-50'
+                    const placarExato = p.golsCasa === r.golsCasa && p.golsVisitante === r.golsVisitante
+                    const vP = Math.sign(p.golsCasa - p.golsVisitante)
+                    const vR = Math.sign(r.golsCasa - r.golsVisitante)
+                    const colunaCerta = vP === vR
+                    const totalGolsCerto = (p.golsCasa + p.golsVisitante) === (r.golsCasa + r.golsVisitante)
+
+                    if (placarExato) {
+                      corClasse = 'text-green-700 bg-green-50 font-bold' // 5 pts
+                    } else if (colunaCerta) {
+                      corClasse = 'text-yellow-700 bg-yellow-50' // 3 pts
+                    } else if (totalGolsCerto) {
+                      corClasse = 'text-blue-700 bg-blue-50' // 1 pt
                     } else {
-                      const vP = Math.sign(p.golsCasa - p.golsVisitante)
-                      const vR = Math.sign(r.golsCasa - r.golsVisitante)
-                      if (vP === vR) {
-                        corClasse = 'text-yellow-700 bg-yellow-50'
-                      } else {
-                        corClasse = 'text-red-400'
-                      }
+                      corClasse = 'text-red-400' // 0 pts
                     }
                   }
 
@@ -235,10 +286,10 @@ export function VerPalpites() {
       {/* Legenda */}
       {jogosFiltrados.some(j => j.encerrado) && (
         <div className="mt-3 flex flex-wrap gap-3 text-xs text-gray-500">
-          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-green-50 border border-green-200" /> Placar exato</span>
-          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-blue-50 border border-blue-200" /> Placar de 1 time</span>
-          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-yellow-50 border border-yellow-200" /> Acertou vencedor</span>
-          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-white border border-gray-200" /> Errou</span>
+          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-green-50 border border-green-200" /> Placar exato (5 pts)</span>
+          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-yellow-50 border border-yellow-200" /> Coluna certa (3 pts)</span>
+          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-blue-50 border border-blue-200" /> Total de gols certo (1 pt)</span>
+          <span className="flex items-center gap-1"><span className="w-3 h-3 rounded text-red-400 border border-gray-200" /> Errou (0 pts)</span>
         </div>
       )}
     </div>


### PR DESCRIPTION
Item 3 do plano.

Resgatados:
- InserirResultados: botoes +/- nos inputs de gols
- VerPalpites: aba Segunda Fase + agrupamento por fase + cores corretas
- VerificarVinculo: useRef em vez de useState pra verificationId + resetRecaptcha + PhoneInput
- PalpitesGeral: tabela de palpites especiais

Pulados (todos com conflito de trabalho de hoje):
- Login.tsx (apenas adicoes nice-to-have)
- Perfil.tsx (Google removal ja feito; resto conflita com photo upload)
- RankingTable.tsx, Palpites.tsx (conflitam com avatar/sticky bar)
- functions/src/index.ts (heavily modified hoje)
- scripts/seed-times.ts (stale)

Stash original preservado intacto.