### PR TITLE
feat(audit): registra login com IP + user-agent + metodo

### DIFF
--- a/functions/src/audit.ts
+++ b/functions/src/audit.ts
@@ -1,5 +1,6 @@
 import * as admin from 'firebase-admin'
 import { onDocumentWritten } from 'firebase-functions/v2/firestore'
+import { onCall, HttpsError } from 'firebase-functions/v2/https'
 
 // audit_log centraliza eventos sensiveis em /audit_log/{autoId}.
 // Schema: {
@@ -22,6 +23,7 @@ interface AuditDoc {
   after: Record<string, unknown> | null
   changedFields: string[]
   at: admin.firestore.Timestamp
+  metadata?: Record<string, unknown>
 }
 
 function diffKeys(
@@ -89,6 +91,45 @@ export const auditPalpitesEspeciais = onDocumentWritten('palpites_especiais/{uid
 
 // Usuarios — captura mudancas em campos sensiveis (liberado, role) ou criacao/exclusao
 const CAMPOS_SENSIVEIS_USUARIO = new Set(['liberado', 'role', 'fotoURL', 'apelido', 'nome', 'email', 'telefone'])
+
+// Callable que registra evento de login. Frontend chama apos cada signIn
+// bem-sucedido. IP e User-Agent sao capturados automaticamente do request.
+export const registrarLogin = onCall(async (request) => {
+  const uid = request.auth?.uid
+  if (!uid) throw new HttpsError('unauthenticated', 'Nao autenticado.')
+
+  const { metodo } = (request.data ?? {}) as { metodo?: string }
+
+  // IP: priorizar X-Forwarded-For (cliente real atras do proxy do Google), fallback raw.ip
+  const headers = request.rawRequest?.headers ?? {}
+  const xff = headers['x-forwarded-for']
+  const ip = (Array.isArray(xff) ? xff[0] : xff?.toString().split(',')[0].trim())
+    || request.rawRequest?.ip
+    || null
+
+  const userAgent = (Array.isArray(headers['user-agent'])
+    ? headers['user-agent'][0]
+    : headers['user-agent']) || null
+
+  const metadata: Record<string, unknown> = {
+    ip,
+    userAgent,
+    metodo: metodo ?? 'desconhecido',
+  }
+
+  await gravar({
+    eventType: 'login',
+    targetUid: uid,
+    targetPath: `auth/${uid}`,
+    before: null,
+    after: null,
+    changedFields: [],
+    at: admin.firestore.Timestamp.now(),
+    metadata,
+  })
+
+  return { ok: true }
+})
 
 export const auditUsuarios = onDocumentWritten('usuarios/{uid}', async (event) => {
   const before = event.data?.before.data() as Record<string, unknown> | undefined

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,7 +3,7 @@ import { onDocumentUpdated } from 'firebase-functions/v2/firestore'
 import { onCall, HttpsError } from 'firebase-functions/v2/https'
 import { recalcularTodoRanking } from './pontuacao'
 export { backupFirestoreDiario } from './backup'
-export { auditPalpites, auditPalpitesEspeciais, auditUsuarios } from './audit'
+export { auditPalpites, auditPalpitesEspeciais, auditUsuarios, registrarLogin } from './audit'
 export { resolverMataMata } from './resolverMataMata'
 
 admin.initializeApp()

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -12,8 +12,18 @@ import {
 } from 'firebase/auth'
 import type { ConfirmationResult } from 'firebase/auth'
 import { doc, getDoc } from 'firebase/firestore'
+import { getFunctions, httpsCallable } from 'firebase/functions'
 import { auth, db } from '../config/firebase'
 import { PhoneInput } from '../components/PhoneInput'
+
+async function registrarLoginNoServer(metodo: 'email_senha' | 'email_link' | 'telefone') {
+  try {
+    const fn = httpsCallable<{ metodo: string }, { ok: boolean }>(getFunctions(), 'registrarLogin')
+    await fn({ metodo })
+  } catch {
+    // Login ja foi bem-sucedido; falha de auditoria nao deve bloquear o usuario.
+  }
+}
 
 type Mode = 'email' | 'emailLink' | 'phone'
 type PhoneStep = 'input' | 'confirm'
@@ -77,6 +87,7 @@ export function Login() {
         setError('Você não tem cadastro no bolão. Solicite um convite ao administrador.')
         return
       }
+      await registrarLoginNoServer('email_link')
       navigate('/')
     } catch (err: unknown) {
       setError(getErrorMessage(err))
@@ -105,6 +116,7 @@ export function Login() {
         setError('Você não tem cadastro no bolão. Solicite um convite ao administrador.')
         return
       }
+      await registrarLoginNoServer('email_senha')
       navigate('/')
     } catch (err: unknown) {
       setError(getErrorMessage(err))
@@ -189,6 +201,7 @@ export function Login() {
         setError('Você não tem cadastro no bolão. Solicite um convite ao administrador.')
         return
       }
+      await registrarLoginNoServer('telefone')
       navigate('/')
     } catch (err: unknown) {
       setError(getErrorMessage(err))

--- a/src/pages/admin/Auditoria.tsx
+++ b/src/pages/admin/Auditoria.tsx
@@ -13,10 +13,12 @@ interface AuditDoc {
   after: Record<string, unknown> | null
   changedFields: string[]
   at: Timestamp
+  metadata?: Record<string, unknown>
 }
 
 const TIPOS_EVENTO = [
   { value: '', label: 'Todos os tipos' },
+  { value: 'login', label: 'Login' },
   { value: 'palpite_create', label: 'Palpite criado' },
   { value: 'palpite_update', label: 'Palpite atualizado' },
   { value: 'palpite_delete', label: 'Palpite excluído' },
@@ -43,6 +45,7 @@ function formatarValor(v: unknown): string {
 
 function CorEvento({ tipo }: { tipo: string }) {
   const map: Record<string, string> = {
+    login: 'bg-sky-100 text-sky-700',
     palpite_create: 'bg-green-100 text-green-700',
     palpite_update: 'bg-blue-100 text-blue-700',
     palpite_delete: 'bg-red-100 text-red-700',
@@ -55,6 +58,29 @@ function CorEvento({ tipo }: { tipo: string }) {
   }
   const cls = map[tipo] ?? 'bg-gray-100 text-gray-700'
   return <span className={`text-[11px] font-semibold rounded-full px-2 py-0.5 ${cls}`}>{tipo}</span>
+}
+
+function MetadataLogin({ metadata }: { metadata?: Record<string, unknown> }) {
+  if (!metadata) return null
+  const ip = (metadata.ip as string | undefined) ?? '—'
+  const userAgent = (metadata.userAgent as string | undefined) ?? '—'
+  const metodo = (metadata.metodo as string | undefined) ?? 'desconhecido'
+  return (
+    <div className="mt-2 text-xs space-y-0.5">
+      <div className="flex flex-wrap gap-1 items-center">
+        <span className="font-semibold text-gray-600">Método:</span>
+        <span className="text-gray-800">{metodo}</span>
+      </div>
+      <div className="flex flex-wrap gap-1 items-center">
+        <span className="font-semibold text-gray-600">IP:</span>
+        <span className="font-mono text-gray-800">{ip}</span>
+      </div>
+      <div className="flex flex-wrap gap-1 items-baseline">
+        <span className="font-semibold text-gray-600">User-Agent:</span>
+        <span className="text-gray-800 break-all">{userAgent}</span>
+      </div>
+    </div>
+  )
 }
 
 function Diff({ before, after, changedFields }: { before: AuditDoc['before']; after: AuditDoc['after']; changedFields: string[] }) {
@@ -181,7 +207,9 @@ export function Auditoria() {
                     <p className="text-[11px] text-gray-500 mt-1">{formatarTimestamp(log.at)}</p>
                   </div>
                 </div>
-                <Diff before={log.before} after={log.after} changedFields={log.changedFields} />
+                {log.eventType === 'login'
+                  ? <MetadataLogin metadata={log.metadata} />
+                  : <Diff before={log.before} after={log.after} changedFields={log.changedFields} />}
               </div>
             )
           })}


### PR DESCRIPTION
Captura IP real do cliente (X-Forwarded-For), user-agent e metodo de login (email/senha, email link, telefone) em audit_log eventType='login'.

Painel /admin/auditoria mostra IP/UA/metodo nos eventos de login.

Paginas acessadas continuam indo para GA4 + BigQuery (mais barato que duplicar em audit_log).