### PR TITLE
fix(classificacao): ordem FIFA correta — head-to-head antes de saldo geral

### DIFF
--- a/functions/src/resolverMataMata.ts
+++ b/functions/src/resolverMataMata.ts
@@ -47,6 +47,9 @@ interface ClassificacaoTime {
 
 // ---- Classificacao do grupo (criterios FIFA: pontos, saldo, gols, mini-tabela) ----
 
+// FIFA Article 13: pontos -> head-to-head (a/b/c) -> geral (d/e/f) -> ranking (skip).
+// Ver detalhes em src/lib/classificacao.ts (este arquivo replica a logica).
+
 function calcularClassificacaoGrupo(
   jogosGrupo: JogoData[],
   timesDoGrupo: string[],
@@ -75,63 +78,80 @@ function calcularClassificacaoGrupo(
   }
 
   const lista = Array.from(map.values())
-  lista.sort(compararCriteriosGerais)
-  return aplicarMiniTabelaEntreEmpatados(lista, jogosGrupo)
+  lista.sort((a, b) => b.pontos - a.pontos)
+
+  const resultado: ClassificacaoTime[] = []
+  let i = 0
+  while (i < lista.length) {
+    let j = i + 1
+    while (j < lista.length && lista[j].pontos === lista[i].pontos) j++
+    const cluster = lista.slice(i, j)
+    if (cluster.length === 1) resultado.push(cluster[0])
+    else resultado.push(...resolverEmpate(cluster, jogosGrupo))
+    i = j
+  }
+  return resultado
 }
 
-function compararCriteriosGerais(a: ClassificacaoTime, b: ClassificacaoTime): number {
-  if (b.pontos !== a.pontos) return b.pontos - a.pontos
-  if (b.saldoGols !== a.saldoGols) return b.saldoGols - a.saldoGols
-  if (b.golsMarcados !== a.golsMarcados) return b.golsMarcados - a.golsMarcados
-  return 0
+interface H2HStat { pontos: number; saldoGols: number; golsMarcados: number }
+
+function calcularH2H(timeIds: string[], jogos: JogoData[]): Map<string, H2HStat> {
+  const set = new Set(timeIds)
+  const map = new Map<string, H2HStat>()
+  for (const id of timeIds) map.set(id, { pontos: 0, saldoGols: 0, golsMarcados: 0 })
+  for (const j of jogos) {
+    if (!j.encerrado || !j.resultado || !j.timeCasa || !j.timeVisitante) continue
+    if (!set.has(j.timeCasa) || !set.has(j.timeVisitante)) continue
+    const c = map.get(j.timeCasa)!
+    const v = map.get(j.timeVisitante)!
+    c.golsMarcados += j.resultado.golsCasa
+    c.saldoGols += j.resultado.golsCasa - j.resultado.golsVisitante
+    v.golsMarcados += j.resultado.golsVisitante
+    v.saldoGols += j.resultado.golsVisitante - j.resultado.golsCasa
+    if (j.resultado.golsCasa > j.resultado.golsVisitante) c.pontos += 3
+    else if (j.resultado.golsCasa < j.resultado.golsVisitante) v.pontos += 3
+    else { c.pontos += 1; v.pontos += 1 }
+  }
+  return map
 }
 
-function mesmosCriteriosGerais(a: ClassificacaoTime, b: ClassificacaoTime): boolean {
+function mesmoH2H(a: H2HStat, b: H2HStat): boolean {
   return a.pontos === b.pontos && a.saldoGols === b.saldoGols && a.golsMarcados === b.golsMarcados
 }
 
-function aplicarMiniTabelaEntreEmpatados(
-  lista: ClassificacaoTime[],
-  jogosGrupo: JogoData[],
-): ClassificacaoTime[] {
-  const r = [...lista]
+function resolverEmpate(empatados: ClassificacaoTime[], jogos: JogoData[]): ClassificacaoTime[] {
+  if (empatados.length <= 1) return empatados
+  const h2h = calcularH2H(empatados.map(t => t.timeId), jogos)
+  const ord = [...empatados].sort((a, b) => {
+    const sa = h2h.get(a.timeId)!
+    const sb = h2h.get(b.timeId)!
+    if (sb.pontos !== sa.pontos) return sb.pontos - sa.pontos
+    if (sb.saldoGols !== sa.saldoGols) return sb.saldoGols - sa.saldoGols
+    if (sb.golsMarcados !== sa.golsMarcados) return sb.golsMarcados - sa.golsMarcados
+    return 0
+  })
+
+  const resultado: ClassificacaoTime[] = []
   let i = 0
-  while (i < r.length) {
+  while (i < ord.length) {
     let j = i + 1
-    while (j < r.length && mesmosCriteriosGerais(r[i], r[j])) j++
-    if (j - i > 1) {
-      const empatados = r.slice(i, j).map(t => t.timeId)
-      const ordemMini = ordenarPorMiniTabela(empatados, jogosGrupo)
-      const porId = new Map(r.map(t => [t.timeId, t]))
-      for (let k = 0; k < ordemMini.length; k++) {
-        const original = porId.get(ordemMini[k])
-        if (original) r[i + k] = original
-      }
-    }
+    const sa = h2h.get(ord[i].timeId)!
+    while (j < ord.length && mesmoH2H(h2h.get(ord[j].timeId)!, sa)) j++
+    const sub = ord.slice(i, j)
+    if (sub.length === 1) resultado.push(sub[0])
+    else if (sub.length === empatados.length) resultado.push(...aplicarCriteriosGerais(sub))
+    else resultado.push(...resolverEmpate(sub, jogos))
     i = j
   }
-  return r
+  return resultado
 }
 
-function ordenarPorMiniTabela(times: string[], jogos: JogoData[]): string[] {
-  const setT = new Set(times)
-  const stat = new Map<string, ClassificacaoTime>()
-  for (const t of times) stat.set(t, { timeId: t, pontos: 0, jogos: 0, vitorias: 0, empates: 0, derrotas: 0, golsMarcados: 0, golsSofridos: 0, saldoGols: 0, grupo: '' })
-
-  for (const j of jogos) {
-    if (!j.encerrado || !j.resultado || !j.timeCasa || !j.timeVisitante) continue
-    if (!setT.has(j.timeCasa) || !setT.has(j.timeVisitante)) continue
-    const c = stat.get(j.timeCasa)!; const v = stat.get(j.timeVisitante)!
-    c.golsMarcados += j.resultado.golsCasa; c.golsSofridos += j.resultado.golsVisitante
-    v.golsMarcados += j.resultado.golsVisitante; v.golsSofridos += j.resultado.golsCasa
-    if (j.resultado.golsCasa > j.resultado.golsVisitante) { c.pontos += 3 }
-    else if (j.resultado.golsCasa < j.resultado.golsVisitante) { v.pontos += 3 }
-    else { c.pontos++; v.pontos++ }
-    c.saldoGols = c.golsMarcados - c.golsSofridos
-    v.saldoGols = v.golsMarcados - v.golsSofridos
-  }
-
-  return Array.from(stat.values()).sort(compararCriteriosGerais).map(t => t.timeId)
+function aplicarCriteriosGerais(empatados: ClassificacaoTime[]): ClassificacaoTime[] {
+  return [...empatados].sort((a, b) => {
+    if (b.saldoGols !== a.saldoGols) return b.saldoGols - a.saldoGols
+    if (b.golsMarcados !== a.golsMarcados) return b.golsMarcados - a.golsMarcados
+    return a.timeId.localeCompare(b.timeId)
+  })
 }
 
 // ---- Comparador de 3os colocados (FIFA) ----

--- a/src/lib/__tests__/classificacao.test.ts
+++ b/src/lib/__tests__/classificacao.test.ts
@@ -79,7 +79,34 @@ describe('calcularClassificacaoGrupo', () => {
     }
   })
 
-  it('deve desempatar por saldo de gols', () => {
+  it('deve aplicar head-to-head ANTES do saldo geral (FIFA Article 13 Step 1)', () => {
+    // Cenario chave que separa o algoritmo antigo do novo:
+    // BRA e ALE empatam em pontos. ALE tem saldo geral MAIOR.
+    // Mas BRA venceu ALE no confronto direto -> Article 13 da prioridade ao h2h.
+    // Pelo Article 13: BRA deve vir primeiro.
+    //
+    // BRA: vence ALE (1-0), perde JAP (0-3), vence CAN (1-0) -> 6 pts, gm 2, gs 3, saldo -1
+    // ALE: perde BRA (0-1), vence JAP (1-0), goleia CAN (5-0) -> 6 pts, gm 6, gs 1, saldo +5
+    // JAP: vence BRA, perde ALE, perde CAN -> 3 pts
+    // CAN: perde BRA, perde ALE, vence JAP -> 3 pts
+    const palpites: Palpite[] = [
+      palpite('j1', 'BRA', 'ALE', 1, 0),
+      palpite('j2', 'JAP', 'CAN', 0, 1),
+      palpite('j3', 'BRA', 'JAP', 0, 3),
+      palpite('j4', 'ALE', 'CAN', 5, 0),
+      palpite('j5', 'BRA', 'CAN', 1, 0),
+      palpite('j6', 'ALE', 'JAP', 1, 0),
+    ]
+    const resultado = calcularClassificacaoGrupo(palpites, times)
+    expect(resultado[0].timeId).toBe('BRA')
+    expect(resultado[1].timeId).toBe('ALE')
+    expect(resultado[0].pontos).toBe(6)
+    expect(resultado[1].pontos).toBe(6)
+    expect(resultado[0].saldoGols).toBe(-1)
+    expect(resultado[1].saldoGols).toBe(5)
+  })
+
+  it('deve desempatar por saldo de gols quando pontos diferentes', () => {
     const palpites: Palpite[] = [
       palpite('j1', 'BRA', 'ALE', 3, 0),
       palpite('j2', 'JAP', 'CAN', 1, 0),

--- a/src/lib/classificacao.ts
+++ b/src/lib/classificacao.ts
@@ -1,5 +1,26 @@
 import type { Palpite, ClassificacaoTime } from '../types'
 
+// Implementa Article 13 do regulamento FIFA Copa 2026 para classificacao
+// dentro do grupo:
+//
+// Entrada: times com pontos iguais (igual numero de pontos no fim da fase
+// de grupos).
+//
+// Step 1 — head-to-head primeiro:
+//   a) Pontos nos jogos entre os empatados
+//   b) Saldo de gols nos jogos entre os empatados
+//   c) Gols marcados nos jogos entre os empatados
+// Se a)-c) deixar sub-grupos ainda empatados, re-aplicar a)-c) mas restritos
+// aos jogos entre os times AINDA empatados.
+//
+// Step 2 — gerais:
+//   d) Saldo de gols geral
+//   e) Gols marcados geral
+//   f) Conduta (cartoes — nao implementado aqui; o bolao nao registra cartoes)
+//
+// Step 3 — FIFA Ranking (nao aplicavel ao bolao). Final fallback determinis-
+// tico por timeId para garantir ordem estavel entre tabela e mata-mata.
+
 export function calcularClassificacaoGrupo(
   palpitesGrupo: Palpite[],
   timesDoGrupo: string[],
@@ -36,71 +57,106 @@ export function calcularClassificacaoGrupo(
     visitante.saldoGols = visitante.golsMarcados - visitante.golsSofridos
   }
 
-  const resultado = Array.from(classificacao.values())
-  resultado.sort(compararCriteriosGerais)
+  const lista = Array.from(classificacao.values())
+  // Ordenar por pontos (entrada do Article 13). Empates em pontos viram
+  // clusters resolvidos em sequencia.
+  lista.sort((a, b) => b.pontos - a.pontos)
 
-  return aplicarMiniTabelaEntreEmpatados(resultado, palpitesGrupo)
-}
-
-function compararCriteriosGerais(a: ClassificacaoTime, b: ClassificacaoTime): number {
-  if (b.pontos !== a.pontos) return b.pontos - a.pontos
-  if (b.saldoGols !== a.saldoGols) return b.saldoGols - a.saldoGols
-  if (b.golsMarcados !== a.golsMarcados) return b.golsMarcados - a.golsMarcados
-  return 0
-}
-
-function mesmosCriteriosGerais(a: ClassificacaoTime, b: ClassificacaoTime): boolean {
-  return a.pontos === b.pontos && a.saldoGols === b.saldoGols && a.golsMarcados === b.golsMarcados
-}
-
-// Criterios 4-6 da FIFA: quando 2+ times permanecem empatados apos pontos/saldo/gols geral,
-// reavaliar so com os jogos entre eles (mini-tabela). Se ainda empatar, mantem a ordem anterior.
-function aplicarMiniTabelaEntreEmpatados(
-  classificacao: ClassificacaoTime[],
-  palpitesGrupo: Palpite[],
-): ClassificacaoTime[] {
-  const resultado = [...classificacao]
+  const resultado: ClassificacaoTime[] = []
   let i = 0
-  while (i < resultado.length) {
+  while (i < lista.length) {
     let j = i + 1
-    while (j < resultado.length && mesmosCriteriosGerais(resultado[i], resultado[j])) j++
-    if (j - i > 1) {
-      const empatados = resultado.slice(i, j).map(t => t.timeId)
-      const ordemMini = ordenarPorMiniTabela(empatados, palpitesGrupo)
-      const porId = new Map(classificacao.map(t => [t.timeId, t]))
-      for (let k = 0; k < ordemMini.length; k++) {
-        const original = porId.get(ordemMini[k])
-        if (original) resultado[i + k] = original
-      }
+    while (j < lista.length && lista[j].pontos === lista[i].pontos) j++
+    const cluster = lista.slice(i, j)
+    if (cluster.length === 1) {
+      resultado.push(cluster[0])
+    } else {
+      resultado.push(...resolverEmpate(cluster, palpitesGrupo))
     }
     i = j
   }
   return resultado
 }
 
-function ordenarPorMiniTabela(timeIds: string[], palpitesGrupo: Palpite[]): string[] {
-  const empatados = new Set(timeIds)
-  const mini: Map<string, ClassificacaoTime> = new Map()
-  for (const id of timeIds) {
-    mini.set(id, {
-      timeId: id, pontos: 0, jogos: 0, vitorias: 0, empates: 0, derrotas: 0,
-      golsMarcados: 0, golsSofridos: 0, saldoGols: 0,
-    })
-  }
+interface H2HStat {
+  pontos: number
+  saldoGols: number
+  golsMarcados: number
+}
+
+function calcularH2H(timeIds: string[], palpitesGrupo: Palpite[]): Map<string, H2HStat> {
+  const set = new Set(timeIds)
+  const map = new Map<string, H2HStat>()
+  for (const id of timeIds) map.set(id, { pontos: 0, saldoGols: 0, golsMarcados: 0 })
   for (const p of palpitesGrupo) {
-    if (!empatados.has(p.timeCasa) || !empatados.has(p.timeVisitante)) continue
-    const casa = mini.get(p.timeCasa)!
-    const visitante = mini.get(p.timeVisitante)!
-    casa.jogos++; visitante.jogos++
-    casa.golsMarcados += p.golsCasa; casa.golsSofridos += p.golsVisitante
-    visitante.golsMarcados += p.golsVisitante; visitante.golsSofridos += p.golsCasa
-    if (p.golsCasa > p.golsVisitante) { casa.pontos += 3 }
-    else if (p.golsCasa < p.golsVisitante) { visitante.pontos += 3 }
-    else { casa.pontos += 1; visitante.pontos += 1 }
-    casa.saldoGols = casa.golsMarcados - casa.golsSofridos
-    visitante.saldoGols = visitante.golsMarcados - visitante.golsSofridos
+    if (!set.has(p.timeCasa) || !set.has(p.timeVisitante)) continue
+    const c = map.get(p.timeCasa)!
+    const v = map.get(p.timeVisitante)!
+    c.golsMarcados += p.golsCasa
+    c.saldoGols += p.golsCasa - p.golsVisitante
+    v.golsMarcados += p.golsVisitante
+    v.saldoGols += p.golsVisitante - p.golsCasa
+    if (p.golsCasa > p.golsVisitante) c.pontos += 3
+    else if (p.golsCasa < p.golsVisitante) v.pontos += 3
+    else { c.pontos += 1; v.pontos += 1 }
   }
-  const tabela = Array.from(mini.values())
-  tabela.sort(compararCriteriosGerais)
-  return tabela.map(t => t.timeId)
+  return map
+}
+
+function mesmoH2H(a: H2HStat, b: H2HStat): boolean {
+  return a.pontos === b.pontos && a.saldoGols === b.saldoGols && a.golsMarcados === b.golsMarcados
+}
+
+// Resolve um grupo de times empatados em pontos aplicando Step 1 da FIFA
+// (head-to-head a/b/c) e, em sub-grupos ainda empatados, recursivamente
+// re-aplicando h2h em escopo restrito. Se h2h nao separar nada, cai para
+// Step 2 (geral d/e/f) e fallback deterministico.
+function resolverEmpate(
+  empatados: ClassificacaoTime[],
+  palpitesGrupo: Palpite[],
+): ClassificacaoTime[] {
+  if (empatados.length <= 1) return empatados
+
+  const h2h = calcularH2H(empatados.map(t => t.timeId), palpitesGrupo)
+
+  const ordenadoH2H = [...empatados].sort((a, b) => {
+    const sa = h2h.get(a.timeId)!
+    const sb = h2h.get(b.timeId)!
+    if (sb.pontos !== sa.pontos) return sb.pontos - sa.pontos
+    if (sb.saldoGols !== sa.saldoGols) return sb.saldoGols - sa.saldoGols
+    if (sb.golsMarcados !== sa.golsMarcados) return sb.golsMarcados - sa.golsMarcados
+    return 0
+  })
+
+  const resultado: ClassificacaoTime[] = []
+  let i = 0
+  while (i < ordenadoH2H.length) {
+    let j = i + 1
+    const sa = h2h.get(ordenadoH2H[i].timeId)!
+    while (j < ordenadoH2H.length && mesmoH2H(h2h.get(ordenadoH2H[j].timeId)!, sa)) j++
+    const sub = ordenadoH2H.slice(i, j)
+    if (sub.length === 1) {
+      resultado.push(sub[0])
+    } else if (sub.length === empatados.length) {
+      // h2h nao separou nenhum -> nao recurse (loop infinito); aplica Step 2
+      resultado.push(...aplicarCriteriosGerais(sub))
+    } else {
+      // sub-grupo restante -> re-aplicar Step 1 entre eles (apenas seus jogos)
+      resultado.push(...resolverEmpate(sub, palpitesGrupo))
+    }
+    i = j
+  }
+  return resultado
+}
+
+// Step 2 (geral) + Step 3 fallback deterministico.
+function aplicarCriteriosGerais(empatados: ClassificacaoTime[]): ClassificacaoTime[] {
+  return [...empatados].sort((a, b) => {
+    if (b.saldoGols !== a.saldoGols) return b.saldoGols - a.saldoGols
+    if (b.golsMarcados !== a.golsMarcados) return b.golsMarcados - a.golsMarcados
+    // Conduta (Step 2 f) nao implementado.
+    // FIFA Ranking (Step 3) nao aplicavel.
+    // Fallback deterministico para tabela e chaveamento nao divergirem.
+    return a.timeId.localeCompare(b.timeId)
+  })
 }

--- a/src/pages/FormatoCopa.tsx
+++ b/src/pages/FormatoCopa.tsx
@@ -49,19 +49,27 @@ export function FormatoCopa() {
         <section className="bg-white rounded-lg shadow p-6 space-y-3">
           <h2 className="text-lg font-bold">Fase de Grupos</h2>
           <p className="text-sm text-gray-600">Cada grupo joga em formato <em>round-robin</em>: todos contra todos (6 jogos por grupo, cada seleção joga 3).</p>
-          <h3 className="font-semibold text-sm mt-3">Classificação dentro do grupo — critérios oficiais FIFA</h3>
+          <h3 className="font-semibold text-sm mt-3">Classificação dentro do grupo — critérios oficiais FIFA (Anexo C / Artigo 13)</h3>
+          <p className="text-xs text-gray-600 mt-1">A pontuação básica (3 por vitória, 1 por empate, 0 por derrota) é o ponto de partida. Quando 2 ou mais times terminam empatados em pontos, a FIFA aplica os critérios abaixo na ordem:</p>
+          <p className="text-xs text-gray-700 font-semibold mt-3">Step 1 — confronto direto entre os empatados:</p>
           <ol className="text-sm list-decimal ml-5 space-y-0.5">
-            <li>Maior número de pontos (vitória = 3, empate = 1, derrota = 0)</li>
-            <li>Maior saldo de gols</li>
-            <li>Maior número de gols marcados</li>
-            <li>Maior número de pontos apenas nos jogos entre os times empatados</li>
-            <li>Maior saldo de gols apenas nos jogos entre os times empatados</li>
-            <li>Maior número de gols marcados apenas nos jogos entre os times empatados</li>
-            <li>Fair play (cartões: amarelo −1, 2º amarelo −3, vermelho direto −4, amarelo + vermelho −5)</li>
-            <li>Sorteio pela FIFA</li>
+            <li>Maior número de pontos nos jogos entre os times empatados</li>
+            <li>Melhor saldo de gols nos jogos entre os times empatados</li>
+            <li>Maior número de gols marcados nos jogos entre os times empatados</li>
           </ol>
-          <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded p-2 mt-2">
-            <strong>Como o Bolão trata esses critérios:</strong> usamos os critérios 1 a 6 exatamente como a FIFA (pontos → saldo → gols → mini-tabela entre empatados). Os critérios 7 (fair play) e 8 (sorteio) não se aplicam aqui porque o palpite não inclui cartões e o sorteio não é previsível. Em caso de empate total após os 6 primeiros critérios, o Bolão mantém a ordem atual da tabela.
+          <p className="text-xs text-gray-700 font-semibold mt-3">Step 2 — só se o Step 1 não resolver, parte para critérios gerais:</p>
+          <ol start={4} className="text-sm list-decimal ml-5 space-y-0.5">
+            <li>Melhor saldo de gols em todos os jogos do grupo</li>
+            <li>Maior número de gols marcados em todos os jogos do grupo</li>
+            <li>Conduta (cartões: amarelo −1, indireto por 2º amarelo −3, vermelho direto −4, amarelo + vermelho direto −5)</li>
+          </ol>
+          <p className="text-xs text-gray-700 font-semibold mt-3">Step 3 — FIFA Ranking:</p>
+          <ol start={7} className="text-sm list-decimal ml-5 space-y-0.5">
+            <li>Posição na edição mais recente do FIFA/Coca‑Cola Men's World Ranking</li>
+            <li>Posição na edição anterior do FIFA/Coca‑Cola Men's World Ranking (e sucessivamente)</li>
+          </ol>
+          <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded p-2 mt-3">
+            <strong>Como o Bolão trata esses critérios:</strong> aplicamos exatamente o Step 1 (head-to-head) primeiro e o Step 2 (saldo e gols geral) depois, conforme o Anexo C. Se um sub-grupo continua empatado após o Step 1, re-aplicamos os critérios head-to-head restritos àqueles times — também conforme a FIFA. O critério 6 (conduta) não dispara hoje porque o palpite não inclui cartões. Os critérios 7 e 8 (FIFA Ranking) também não se aplicam. Em caso de empate total persistente, o Bolão usa um desempate determinístico (alfabético por id do time) para que a tabela e o chaveamento do mata-mata não divirjam.
           </p>
           <h3 className="font-semibold text-sm mt-3">Quem avança?</h3>
           <ul className="text-sm list-disc ml-5 space-y-0.5">


### PR DESCRIPTION
Article 13 / Anexo C exige aplicar head-to-head antes dos criterios gerais. O bolao fazia o oposto. Caso real: time A com saldo geral +5 perde do B no confronto direto -> bolao colocava A primeiro, FIFA coloca B.

Refator de `src/lib/classificacao.ts` (com testes) + replica em `functions/src/resolverMataMata.ts` + correcao do texto em /formato-copa.