### PR TITLE
fix(versao): corrigir detecção de nova versão via Firestore

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -56,3 +56,13 @@ jobs:
 
       - name: Deploy Firebase (hosting + rules + indexes + functions)
         run: firebase deploy --only hosting,firestore,functions --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }} --non-interactive --force
+
+      - name: Atualizar config/app_version no Firestore
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          TOKEN=$(gcloud auth print-access-token)
+          curl -s -X PATCH \
+            "https://firestore.googleapis.com/v1/projects/${{ secrets.VITE_FIREBASE_PROJECT_ID }}/databases/(default)/documents/config/app_version?updateMask.fieldPaths=build" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"fields\":{\"build\":{\"stringValue\":\"$SHA\"}}}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -56,3 +56,13 @@ jobs:
 
       - name: Deploy Firebase (hosting + rules + indexes + functions)
         run: firebase deploy --only hosting,firestore,functions --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }} --non-interactive --force
+
+      - name: Atualizar config/app_version no Firestore
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          TOKEN=$(gcloud auth print-access-token)
+          curl -s -X PATCH \
+            "https://firestore.googleapis.com/v1/projects/${{ secrets.VITE_FIREBASE_PROJECT_ID }}/databases/(default)/documents/config/app_version?updateMask.fieldPaths=build" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"fields\":{\"build\":{\"stringValue\":\"$SHA\"}}}"

--- a/firestore.rules
+++ b/firestore.rules
@@ -106,6 +106,12 @@ service cloud.firestore {
         && request.resource.data.conviteId == resource.data.conviteId;
     }
 
+    // /config/app_version: leitura pública (não é dado sensível, necessário para detecção de nova versão sem auth)
+    match /config/app_version {
+      allow read: if true;
+      allow write: if isAdmin();
+    }
+
     // /config/{docId}: read by authenticated, write by admin
     // Inclui config/geral e config/resultado_especial
     match /config/{docId} {


### PR DESCRIPTION
## Summary
- `config/app_version` passa a ter leitura pública (não é dado sensível — era desnecessário exigir auth)
- Ambos os deploys (dev e prod) agora atualizam `config/app_version.build` com o SHA do commit após cada deploy
- Isso ativa o listener Firestore em `useAppVersion`, que detecta nova versão instantaneamente para usuários autenticados
- Elimina o erro `permission-denied` no console

🤖 Generated with [Claude Code](https://claude.com/claude-code)