### PR TITLE
fix: reverter config/app_version — NUNCA criar docs na colecao config

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -56,13 +56,3 @@ jobs:
 
       - name: Deploy Firebase (hosting + rules + indexes + functions)
         run: firebase deploy --only hosting,firestore,functions --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }} --non-interactive --force
-
-      - name: Atualizar config/app_version no Firestore
-        run: |
-          SHA=$(git rev-parse --short HEAD)
-          TOKEN=$(gcloud auth print-access-token)
-          curl -s -X PATCH \
-            "https://firestore.googleapis.com/v1/projects/${{ secrets.VITE_FIREBASE_PROJECT_ID }}/databases/(default)/documents/config/app_version?updateMask.fieldPaths=build" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"fields\":{\"build\":{\"stringValue\":\"$SHA\"}}}"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -57,12 +57,3 @@ jobs:
       - name: Deploy Firebase (hosting + rules + indexes + functions)
         run: firebase deploy --only hosting,firestore,functions --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }} --non-interactive --force
 
-      - name: Atualizar config/app_version no Firestore
-        run: |
-          SHA=$(git rev-parse --short HEAD)
-          TOKEN=$(gcloud auth print-access-token)
-          curl -s -X PATCH \
-            "https://firestore.googleapis.com/v1/projects/${{ secrets.VITE_FIREBASE_PROJECT_ID }}/databases/(default)/documents/config/app_version?updateMask.fieldPaths=build" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "{\"fields\":{\"build\":{\"stringValue\":\"$SHA\"}}}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # ⛔⛔⛔ DIRETIVA DE SEGURANCA — TOPO DE TUDO ⛔⛔⛔
 
+## JAMAIS CRIAR DOCUMENTOS NA COLECAO `config` DO FIRESTORE
+
+A colecao `config` so pode ter os documentos `geral` e `resultado_especial`. Qualquer outro documento nessa colecao quebra leituras que dependem da estrutura conhecida. Em 2026-04-30 foi criado `config/app_version` e isso quebrou a pagina de palpites em producao com erro `Cannot read properties of undefined (reading 'toDate')`.
+
+**Regra:** Se precisar armazenar qualquer outro dado de sistema no Firestore, usar uma colecao separada (ex: `_system/versao`, `meta/app_version`). NUNCA adicionar documentos a colecao `config`.
+
+---
+
 ## JAMAIS RODAR `git stash` SEM CONSENTIMENTO EXPLICITO DO USUARIO
 
 Inclui qualquer variante: `git stash`, `git stash push|save|create|store|apply|pop|drop|clear`, e flags de auto-stash em outros comandos (`git pull --autostash`, `git rebase --autostash`).

--- a/firestore.rules
+++ b/firestore.rules
@@ -106,12 +106,6 @@ service cloud.firestore {
         && request.resource.data.conviteId == resource.data.conviteId;
     }
 
-    // /config/app_version: leitura pública (não é dado sensível, necessário para detecção de nova versão sem auth)
-    match /config/app_version {
-      allow read: if true;
-      allow write: if isAdmin();
-    }
-
     // /config/{docId}: read by authenticated, write by admin
     // Inclui config/geral e config/resultado_especial
     match /config/{docId} {

--- a/src/hooks/useAppVersion.ts
+++ b/src/hooks/useAppVersion.ts
@@ -1,25 +1,10 @@
 import { useEffect, useState } from 'react'
-import { doc, onSnapshot } from 'firebase/firestore'
-import { db } from '../config/firebase'
-import { useAuth } from './useAuth'
-import type { AppVersion } from '../types'
 
 const POLL_INTERVAL_MS = 2 * 60 * 1000
 
-// Estrategia em duas camadas:
-// 1) Listener Firestore em /config/app_version: invalidacao instantanea quando
-//    o doc e atualizado depois de um deploy. So inicia se o usuario estiver
-//    autenticado, para nao gerar permission-denied em telas publicas (login,
-//    cadastro). Se nao autenticado, o polling cobre.
-// 2) Polling em /version.json a cada 2 min como rede de seguranca, caso o
-//    listener falhe, esteja offline ou o doc nao tenha sido atualizado.
-// Em ambos os casos comparamos contra __APP_VERSION__ injetado no bundle pelo
-// vite.config (git short SHA).
 export function useAppVersion() {
-  const { firebaseUser } = useAuth()
   const [hasUpdate, setHasUpdate] = useState(false)
 
-  // Polling (sempre rodando, autenticado ou nao)
   useEffect(() => {
     let cancelled = false
 
@@ -50,27 +35,6 @@ export function useAppVersion() {
       document.removeEventListener('visibilitychange', onVisible)
     }
   }, [])
-
-  // Listener Firestore — so quando autenticado (rules exigem auth)
-  useEffect(() => {
-    if (!firebaseUser) return
-
-    const unsub = onSnapshot(
-      doc(db, 'config', 'app_version'),
-      (snap) => {
-        if (!snap.exists()) return
-        const data = snap.data() as AppVersion | undefined
-        if (data?.build && data.build !== __APP_VERSION__) {
-          setHasUpdate(true)
-        }
-      },
-      () => {
-        // Erro no listener (offline, rules, etc): polling cobre.
-      },
-    )
-
-    return () => unsub()
-  }, [firebaseUser])
 
   return { hasUpdate, reload: () => window.location.reload() }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,12 +106,6 @@ export interface Ranking {
 
 export type Role = 'admin' | 'participante'
 
-export interface AppVersion {
-  build: string
-  deployedAt: Timestamp
-  atualizadoPor?: string
-}
-
 export interface Usuario {
   uid: string
   nome: string


### PR DESCRIPTION
## Summary
- Remove listener Firestore de config/app_version — causava crash nos palpites
- Remove step dos workflows que criava config/app_version
- Remove regra config/app_version do firestore.rules
- Adiciona diretiva no CLAUDE.md proibindo novos documentos na coleção config
- O polling de /version.json continua funcionando para detectar novas versões

🤖 Generated with [Claude Code](https://claude.com/claude-code)