### PR TITLE
feat(ranking): colunas de palpite ao vivo por participante

### DIFF
--- a/src/components/RankingTable.tsx
+++ b/src/components/RankingTable.tsx
@@ -1,18 +1,105 @@
-import type { Ranking, Usuario } from '../types'
+import type { Ranking, Usuario, Jogo, Time, Palpite } from '../types'
+import { calcularPontosPalpite } from '../lib/pontuacao'
 import { Avatar } from './Avatar'
+
+export interface JogoAoVivoRanking {
+  jogo: Jogo
+  timeCasa: Time | null
+  timeVisitante: Time | null
+}
+
+interface PontosCfg {
+  placarExato: number
+  colunaCerta: number
+  totalGols: number
+}
+
+// Mesmo fallback usado em AoVivo.tsx — evita divergência visual (células cinza
+// na tabela enquanto o card AoVivo já mostra verde) na janela antes de config carregar.
+const PONTOS_FALLBACK: PontosCfg = { placarExato: 10, colunaCerta: 3, totalGols: 1 }
 
 interface Props {
   ranking: (Ranking & { usuario: Usuario })[]
+  /** Jogos ao vivo cujas colunas de palpite devem aparecer entre "#" e "Participante". */
+  jogosAoVivo?: JogoAoVivoRanking[]
+  /** Palpites por participante, indexados por `${uid}_${jogoId}`. */
+  palpitesLive?: Map<string, Palpite>
+  pontosCfg?: PontosCfg
 }
 
-export function RankingTable({ ranking }: Props) {
+function CelulaPalpite({
+  palpite,
+  jogo,
+  pontosCfg,
+}: {
+  palpite: Palpite | undefined
+  jogo: Jogo
+  pontosCfg: PontosCfg
+}) {
+  if (!palpite) {
+    return <span className="text-gray-300">—</span>
+  }
+
+  // Verde quando o palpite já está pontuando contra o placar atual ao vivo.
+  let acertando = false
+  if (jogo.resultado) {
+    acertando =
+      calcularPontosPalpite(
+        { golsCasa: palpite.golsCasa, golsVisitante: palpite.golsVisitante },
+        { golsCasa: jogo.resultado.golsCasa, golsVisitante: jogo.resultado.golsVisitante },
+        pontosCfg,
+      ).pontos > 0
+  }
+
+  return (
+    <span
+      className={`inline-block rounded px-1.5 py-0.5 text-xs font-bold tabular-nums ${
+        acertando ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'
+      }`}
+    >
+      {palpite.golsCasa}x{palpite.golsVisitante}
+    </span>
+  )
+}
+
+export function RankingTable({ ranking, jogosAoVivo = [], palpitesLive, pontosCfg }: Props) {
+  const cfg = pontosCfg ?? PONTOS_FALLBACK
+
   return (
     <div className="overflow-x-auto">
       <table className="w-full bg-white rounded shadow">
         <thead className="bg-blue-800 text-white text-sm">
           <tr>
             <th className="px-3 py-2 text-left">#</th>
-            <th className="px-3 py-2 text-left">Participante</th>
+            {jogosAoVivo.map(({ jogo, timeCasa, timeVisitante }) => (
+              <th key={jogo.id} className="px-2 py-2 text-center whitespace-nowrap">
+                <div className="flex items-center justify-center gap-1">
+                  {timeCasa?.bandeira && (
+                    <img
+                      src={timeCasa.bandeira}
+                      alt={timeCasa.nome ?? ''}
+                      title={timeCasa.nome ?? ''}
+                      className="w-5 h-3.5 object-cover rounded-sm shrink-0"
+                    />
+                  )}
+                  {/* Placar atual ao vivo — torna o destaque verde interpretável. */}
+                  <span className="text-xs font-black tabular-nums">
+                    {jogo.resultado ? `${jogo.resultado.golsCasa}-${jogo.resultado.golsVisitante}` : '–'}
+                  </span>
+                  {timeVisitante?.bandeira && (
+                    <img
+                      src={timeVisitante.bandeira}
+                      alt={timeVisitante.nome ?? ''}
+                      title={timeVisitante.nome ?? ''}
+                      className="w-5 h-3.5 object-cover rounded-sm shrink-0"
+                    />
+                  )}
+                </div>
+              </th>
+            ))}
+            {/* Participante fica sticky à esquerda: ao rolar para inspecionar os
+                palpites de vários jogos, o nome da linha continua visível. */}
+            <th className="px-3 py-2 text-left sticky left-0 bg-blue-800 z-10">Participante</th>
             <th className="px-3 py-2 text-center">Pontos</th>
             <th className="px-3 py-2 text-center">Exatos</th>
             <th className="px-3 py-2 text-center">Coluna</th>
@@ -20,27 +107,44 @@ export function RankingTable({ ranking }: Props) {
           </tr>
         </thead>
         <tbody>
-          {ranking.map((r, i) => (
-            <tr key={r.uid} className={i % 2 === 0 ? 'bg-gray-50' : ''}>
-              <td className="px-3 py-2 font-bold">{i + 1}</td>
-              <td className="px-3 py-2">
-                <div className="flex items-center gap-2">
-                  <Avatar
-                    src={r.usuario.fotoURL ?? null}
-                    nome={r.usuario.apelido || r.usuario.nome}
-                    uid={r.usuario.uid}
-                    size="sm"
-                    ring={false}
-                  />
-                  <span className="truncate">{r.usuario.apelido || r.usuario.nome}</span>
-                </div>
-              </td>
-              <td className="px-3 py-2 text-center font-bold">{r.pontosTotal}</td>
-              <td className="px-3 py-2 text-center">{r.placaresExatos}</td>
-              <td className="px-3 py-2 text-center">{r.colunasCertas}</td>
-              <td className="px-3 py-2 text-center">{r.totalGolsAcertados}</td>
-            </tr>
-          ))}
+          {ranking.map((r, i) => {
+            const bg = i % 2 === 0 ? 'bg-gray-50' : 'bg-white'
+            return (
+              <tr key={r.uid} className={i % 2 === 0 ? 'bg-gray-50' : ''}>
+                <td className="px-3 py-2 font-bold">{i + 1}</td>
+                {jogosAoVivo.map(({ jogo }) => (
+                  <td key={jogo.id} className="px-2 py-2 text-center">
+                    <CelulaPalpite
+                      palpite={palpitesLive?.get(`${r.uid}_${jogo.id}`)}
+                      jogo={jogo}
+                      pontosCfg={cfg}
+                    />
+                  </td>
+                ))}
+                <td className={`px-3 py-2 sticky left-0 z-10 ${bg}`}>
+                  <div className="flex items-center gap-2">
+                    <Avatar
+                      src={r.usuario.fotoURL ?? null}
+                      nome={r.usuario.apelido || r.usuario.nome}
+                      uid={r.usuario.uid}
+                      size="sm"
+                      ring={false}
+                    />
+                    {(() => {
+                      const nome = r.usuario.apelido || r.usuario.nome
+                      const exibido = nome.length > 15 ? `${nome.slice(0, 15)}…` : nome
+                      // title mostra o nome completo no hover (desktop) e long-press (mobile).
+                      return <span title={nome}>{exibido}</span>
+                    })()}
+                  </div>
+                </td>
+                <td className="px-3 py-2 text-center font-bold">{r.pontosTotal}</td>
+                <td className="px-3 py-2 text-center">{r.placaresExatos}</td>
+                <td className="px-3 py-2 text-center">{r.colunasCertas}</td>
+                <td className="px-3 py-2 text-center">{r.totalGolsAcertados}</td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/src/components/RankingTable.tsx
+++ b/src/components/RankingTable.tsx
@@ -2,21 +2,14 @@ import type { Ranking, Usuario, Jogo, Time, Palpite } from '../types'
 import { calcularPontosPalpite } from '../lib/pontuacao'
 import { Avatar } from './Avatar'
 
+// Config unitária: só usamos o `tipo` de acerto, que independe dos valores de pontos.
+const PONTOS_UNIT = { placarExato: 1, colunaCerta: 1, totalGols: 1 }
+
 export interface JogoAoVivoRanking {
   jogo: Jogo
   timeCasa: Time | null
   timeVisitante: Time | null
 }
-
-interface PontosCfg {
-  placarExato: number
-  colunaCerta: number
-  totalGols: number
-}
-
-// Mesmo fallback usado em AoVivo.tsx — evita divergência visual (células cinza
-// na tabela enquanto o card AoVivo já mostra verde) na janela antes de config carregar.
-const PONTOS_FALLBACK: PontosCfg = { placarExato: 10, colunaCerta: 3, totalGols: 1 }
 
 interface Props {
   ranking: (Ranking & { usuario: Usuario })[]
@@ -24,46 +17,43 @@ interface Props {
   jogosAoVivo?: JogoAoVivoRanking[]
   /** Palpites por participante, indexados por `${uid}_${jogoId}`. */
   palpitesLive?: Map<string, Palpite>
-  pontosCfg?: PontosCfg
 }
 
 function CelulaPalpite({
   palpite,
   jogo,
-  pontosCfg,
 }: {
   palpite: Palpite | undefined
   jogo: Jogo
-  pontosCfg: PontosCfg
 }) {
   if (!palpite) {
     return <span className="text-gray-300">—</span>
   }
 
-  // Verde quando o palpite já está pontuando contra o placar atual ao vivo.
-  let acertando = false
+  // Cor pelo tipo de pontuação REAL (calcularPontosPalpite), aplicada ao placar
+  // atual ao vivo: exato → verde, coluna/vencedor → amarelo, total de gols → azul,
+  // não pontuou → vermelho.
+  let corClasse = 'text-gray-700'
   if (jogo.resultado) {
-    acertando =
-      calcularPontosPalpite(
-        { golsCasa: palpite.golsCasa, golsVisitante: palpite.golsVisitante },
-        { golsCasa: jogo.resultado.golsCasa, golsVisitante: jogo.resultado.golsVisitante },
-        pontosCfg,
-      ).pontos > 0
+    const { tipo } = calcularPontosPalpite(
+      { golsCasa: palpite.golsCasa, golsVisitante: palpite.golsVisitante },
+      { golsCasa: jogo.resultado.golsCasa, golsVisitante: jogo.resultado.golsVisitante },
+      PONTOS_UNIT,
+    )
+    if (tipo === 'placarExato') corClasse = 'text-green-700 bg-green-50 font-bold'
+    else if (tipo === 'colunaCerta') corClasse = 'text-yellow-700 bg-yellow-50'
+    else if (tipo === 'totalGols') corClasse = 'text-blue-700 bg-blue-50'
+    else corClasse = 'text-red-400'
   }
 
   return (
-    <span
-      className={`inline-block rounded px-1.5 py-0.5 text-xs font-bold tabular-nums ${
-        acertando ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'
-      }`}
-    >
+    <span className={`inline-block rounded px-1.5 py-0.5 text-xs font-mono ${corClasse}`}>
       {palpite.golsCasa}x{palpite.golsVisitante}
     </span>
   )
 }
 
-export function RankingTable({ ranking, jogosAoVivo = [], palpitesLive, pontosCfg }: Props) {
-  const cfg = pontosCfg ?? PONTOS_FALLBACK
+export function RankingTable({ ranking, jogosAoVivo = [], palpitesLive }: Props) {
 
   return (
     <div className="overflow-x-auto">
@@ -109,6 +99,8 @@ export function RankingTable({ ranking, jogosAoVivo = [], palpitesLive, pontosCf
         <tbody>
           {ranking.map((r, i) => {
             const bg = i % 2 === 0 ? 'bg-gray-50' : 'bg-white'
+            const nome = r.usuario.apelido || r.usuario.nome
+            const nomeExibido = nome.length > 15 ? `${nome.slice(0, 15)}…` : nome
             return (
               <tr key={r.uid} className={i % 2 === 0 ? 'bg-gray-50' : ''}>
                 <td className="px-3 py-2 font-bold">{i + 1}</td>
@@ -117,7 +109,6 @@ export function RankingTable({ ranking, jogosAoVivo = [], palpitesLive, pontosCf
                     <CelulaPalpite
                       palpite={palpitesLive?.get(`${r.uid}_${jogo.id}`)}
                       jogo={jogo}
-                      pontosCfg={cfg}
                     />
                   </td>
                 ))}
@@ -130,12 +121,8 @@ export function RankingTable({ ranking, jogosAoVivo = [], palpitesLive, pontosCf
                       size="sm"
                       ring={false}
                     />
-                    {(() => {
-                      const nome = r.usuario.apelido || r.usuario.nome
-                      const exibido = nome.length > 15 ? `${nome.slice(0, 15)}…` : nome
-                      // title mostra o nome completo no hover (desktop) e long-press (mobile).
-                      return <span title={nome}>{exibido}</span>
-                    })()}
+                    {/* title mostra o nome completo no hover (desktop) e long-press (mobile). */}
+                    <span title={nome}>{nomeExibido}</span>
                   </div>
                 </td>
                 <td className="px-3 py-2 text-center font-bold">{r.pontosTotal}</td>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react'
-import { collection, getDocs } from 'firebase/firestore'
+import { useEffect, useMemo, useState } from 'react'
+import { collection, doc, getDocs, onSnapshot, query, where } from 'firebase/firestore'
 import { db } from '../config/firebase'
-import type { Ranking, Usuario } from '../types'
+import type { Ranking, Usuario, Jogo, Time, Palpite, Config } from '../types'
 import { Navbar } from '../components/Navbar'
-import { RankingTable } from '../components/RankingTable'
+import { RankingTable, type JogoAoVivoRanking } from '../components/RankingTable'
 import { RankingDestaques } from '../components/RankingDestaques'
 import { AoVivo } from '../components/AoVivo'
 import { useAuth } from '../hooks/useAuth'
@@ -28,6 +28,94 @@ export function Ranking() {
   const { firebaseUser } = useAuth()
   const [ranking, setRanking] = useState<RankingComUsuario[]>([])
   const [loading, setLoading] = useState(true)
+
+  // Estado para as colunas de palpite ao vivo na tabela.
+  const [config, setConfig] = useState<Config | null>(null)
+  const [times, setTimes] = useState<Map<string, Time>>(new Map())
+  const [jogosLive, setJogosLive] = useState<Jogo[]>([])
+  const [palpitesLive, setPalpitesLive] = useState<Map<string, Palpite>>(new Map())
+
+  // Times — carregados uma vez (não mudam com frequência).
+  useEffect(() => {
+    getDocs(collection(db, 'times')).then((snap) => {
+      const m = new Map<string, Time>()
+      snap.docs.forEach((d) => m.set(d.id, { id: d.id, ...d.data() } as Time))
+      setTimes(m)
+    }).catch(() => { /* offline — ignora */ })
+  }, [])
+
+  // Config (pontos, visibilidade, prazo) em tempo real: se o admin mudar a
+  // visibilidade durante um jogo ao vivo, recomputamos podeVerAlheios sem reload.
+  useEffect(() => {
+    const unsub = onSnapshot(doc(db, 'config', 'geral'), (snap) => {
+      if (snap.exists()) setConfig(snap.data() as Config)
+    }, () => { /* offline — ignora */ })
+    return () => unsub()
+  }, [])
+
+  // Jogos ao vivo (tempo real — o placar muda durante o jogo).
+  useEffect(() => {
+    const q = query(collection(db, 'jogos'), where('aoVivo', '==', true))
+    const unsub = onSnapshot(q, (snap) => {
+      setJogosLive(snap.docs.map((d) => ({ id: d.id, ...d.data() } as Jogo)))
+    }, () => { /* sem jogos ao vivo ou sem permissão — ignora */ })
+    return () => unsub()
+  }, [])
+
+  // Instante de montagem — lido uma vez (Date.now é impuro no render reativo).
+  const [agoraMs] = useState(() => Date.now())
+
+  // Só dá para mostrar palpites de TODOS os participantes quando as regras de
+  // visibilidade permitem (mesmas condições de canReadPalpite no firestore.rules
+  // para um jogo ao vivo, que nunca está encerrado).
+  const podeVerAlheios = useMemo(() => {
+    if (!config) return false
+    if (config.visibilidadePalpites === 'sempre') return true
+    if (config.visibilidadePalpites === 'apos_prazo') {
+      return agoraMs >= config.prazoLimitePalpites.toMillis()
+    }
+    return false // 'apos_jogo' (jogo ao vivo não encerrado) ou 'nunca'
+  }, [config, agoraMs])
+
+  // Jogos ao vivo ordenados e limitados a 30 (limite do operador 'in' do
+  // Firestore) — fonte única para as colunas E para a query de palpites, para
+  // que cabeçalho e dados nunca divirjam.
+  const jogosAoVivo = useMemo<JogoAoVivoRanking[]>(() => {
+    if (!podeVerAlheios) return []
+    return [...jogosLive]
+      .sort((a, b) => a.dataHora.toMillis() - b.dataHora.toMillis())
+      .slice(0, 30)
+      .map((jogo) => ({
+        jogo,
+        timeCasa: times.get(jogo.timeCasa) ?? null,
+        timeVisitante: times.get(jogo.timeVisitante) ?? null,
+      }))
+  }, [podeVerAlheios, jogosLive, times])
+
+  // Chave estável: só muda quando o CONJUNTO de jogos ao vivo muda (entra/sai
+  // jogo), não a cada gol. Evita refazer o getDocs de palpites a cada placar.
+  const liveKey = useMemo(() => jogosAoVivo.map((j) => j.jogo.id).join(','), [jogosAoVivo])
+
+  // Palpites de todos os participantes para os jogos ao vivo. Palpites não mudam
+  // durante o jogo (prazo fechado), então uma leitura pontual basta.
+  useEffect(() => {
+    const ids = liveKey ? liveKey.split(',') : []
+    // Sem jogos ao vivo / sem permissão: jogosAoVivo é [], então as colunas não
+    // renderizam e um palpitesLive obsoleto nunca é consultado — não precisa limpar.
+    if (!podeVerAlheios || ids.length === 0) return
+    let cancelado = false
+    const q = query(collection(db, 'palpites'), where('jogoId', 'in', ids))
+    getDocs(q).then((snap) => {
+      if (cancelado) return
+      const m = new Map<string, Palpite>()
+      snap.docs.forEach((d) => {
+        const p = { id: d.id, ...d.data() } as Palpite
+        m.set(`${p.uid}_${p.jogoId}`, p)
+      })
+      setPalpitesLive(m)
+    }).catch(() => { /* sem permissão ou offline — sem colunas */ })
+    return () => { cancelado = true }
+  }, [podeVerAlheios, liveKey])
 
   useEffect(() => {
     async function load() {
@@ -78,7 +166,7 @@ export function Ranking() {
   return (
     <div className="min-h-screen bg-gray-50">
       <Navbar />
-      <main className="max-w-3xl mx-auto px-6 py-10">
+      <main className="max-w-3xl mx-auto px-2 sm:px-6 py-6 sm:py-10">
         {firebaseUser && <AoVivo uid={firebaseUser.uid} />}
 
         <h1 className="text-2xl font-bold text-gray-800 mb-6">Ranking</h1>
@@ -89,7 +177,12 @@ export function Ranking() {
         ) : (
           <>
             <RankingDestaques ranking={ranking} />
-            <RankingTable ranking={ranking} />
+            <RankingTable
+              ranking={ranking}
+              jogosAoVivo={jogosAoVivo}
+              palpitesLive={palpitesLive}
+              pontosCfg={config?.pontos}
+            />
           </>
         )}
       </main>

--- a/src/pages/Ranking.tsx
+++ b/src/pages/Ranking.tsx
@@ -181,7 +181,6 @@ export function Ranking() {
               ranking={ranking}
               jogosAoVivo={jogosAoVivo}
               palpitesLive={palpitesLive}
-              pontosCfg={config?.pontos}
             />
           </>
         )}


### PR DESCRIPTION
Promove para produção a feature de **palpites ao vivo no ranking** (PR #36, já mergeado em `dev` e publicado no ambiente de teste).

## O que vai para produção

Na tela `/ranking`, quando há jogo(s) **ao vivo**, surgem colunas entre **#** e **Participante** — uma por jogo — com o palpite de cada participante e o **placar atual ao vivo** no cabeçalho.

- **Cores por pontuação real** (`calcularPontosPalpite`): exato → 🟢 verde, coluna/vencedor → 🟡 amarelo, total de gols → 🔵 azul, não pontuou → 🔴 vermelho
- **Tempo real** via `onSnapshot`; re-fetch de palpites só quando entra/sai jogo (não a cada gol)
- **Segurança:** só ativa quando as regras permitem ler palpites alheios (`canReadPalpite`: `'sempre'` ou `'apos_prazo'` vencido)
- **UX:** coluna Participante `sticky` no mobile; nome truncado em 15 chars com nome completo no `title`; borda lateral menor no mobile

## Escopo

Diff de 3 pontos a partir do ancestral comum `3e28362` — contém **apenas** os 2 commits da feature do ranking (`32c7726`, `acdba47`). Os arquivos tocados (`Ranking.tsx`, `RankingTable.tsx`) não foram alterados em `main`.

> ℹ️ `dev` está 12 commits atrás de `main`; esses commits já estão em produção e não são afetados por este PR. Atualizar `dev` com `main` é um passo separado planejado.

## Verificação
- `tsc -b` limpo ✅ · ESLint limpo ✅ · 26 testes ✅ · build OK ✅
- Publicado e validado no ambiente de teste (`bolao-do-bolero-teste`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)