### PR TITLE
fix(clinch): 2º de grupo completo empatado em pontos com o 3º (CAN/AUS sem ✓)

### DIFF
--- a/src/lib/__tests__/clinchMataMata.test.ts
+++ b/src/lib/__tests__/clinchMataMata.test.ts
@@ -83,4 +83,25 @@ describe('calcularClassificadosMataMata', () => {
     expect(r.has('A1')).toBe(true)
     expect(r.has('A2')).toBe(true)
   })
+
+  it('classifica o 2º de grupo COMPLETO empatado em pontos com o 3º (desempate por saldo) — regressão CAN/AUS', () => {
+    // 9 grupos completos idênticos. Em cada um: 1º=9pts; 2º e 3º empatam em 4 pts (o 2º só fica
+    // à frente pelo SALDO geral); 4º=0. Com 9 grupos, nenhum 3º (4 pts) está garantido via melhor
+    // terceiro — então o ✓ do 2º depende de reconhecer a posição REAL (top-2), não a contagem por pontos.
+    const letras = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']
+    const grupos: GrupoRef[] = letras.map(L => ({ nome: `Grupo ${L}`, times: [`${L}1`, `${L}2`, `${L}3`, `${L}4`] }))
+    const jogos: JogoCalc[] = letras.flatMap(L => {
+      const t = [`${L}1`, `${L}2`, `${L}3`, `${L}4`]
+      return [
+        jg(L, t[0], t[1], [1, 0]), jg(L, t[0], t[2], [1, 0]), jg(L, t[0], t[3], [1, 0]), // 1º vence todos
+        jg(L, t[1], t[2], [2, 2]), // 2º e 3º empatam no confronto direto
+        jg(L, t[1], t[3], [5, 0]), // 2º goleia o 4º → saldo +4
+        jg(L, t[2], t[3], [1, 0]), // 3º vence o 4º → saldo 0
+      ]
+    })
+    const r = calcularClassificadosMataMata(jogos, grupos)
+    expect(r.has('A2')).toBe(true) // 2º real (por saldo) — DEVE estar classificado (top-2)
+    expect(r.has('A1')).toBe(true) // 1º
+    expect(r.has('A3')).toBe(false) // 3º não garantido entre os 8 melhores
+  })
 })

--- a/src/lib/clinchMataMata.ts
+++ b/src/lib/clinchMataMata.ts
@@ -1,6 +1,8 @@
 import type { JogoCalc as Jogo } from '../types/calc'
 import type { GrupoRef } from './bracketUsuario'
 import { calcularClinchGrupo, type ClinchTime } from './clinchGrupo'
+import { calcularClassificacaoGrupo } from './classificacao'
+import { jogoParaPalpiteReal } from './resultadosOficiais'
 
 /**
  * Clinch de classificação para o MATA-MATA (cross-group), considerando que a Copa
@@ -43,6 +45,17 @@ function analisarGrupo(jogosDoGrupo: Jogo[], times: string[]): AnaliseGrupo {
     if (gc > gv) pontosAtuais[j.timeCasa] += 3
     else if (gc < gv) pontosAtuais[j.timeVisitante] += 3
     else { pontosAtuais[j.timeCasa] += 1; pontosAtuais[j.timeVisitante] += 1 }
+  }
+
+  // Grupo COMPLETO: a classificação é final e determinística (com desempate FIFA por
+  // saldo/critérios). A contagem conservadora por pontos abaixo não desempata por saldo, o
+  // que tiraria indevidamente o ✓ de um 2º colocado empatado em pontos com o 3º (ex.: CAN/AUS).
+  if (restantes.length === 0) {
+    const cls = calcularClassificacaoGrupo(encerrados.map(jogoParaPalpiteReal), times)
+    const pior: Record<string, number> = {}
+    const melhor: Record<string, number> = {}
+    cls.forEach((c, i) => { pior[c.timeId] = i + 1; melhor[c.timeId] = i + 1 })
+    return { pontosAtuais, piorPosicao: pior, melhorPosicao: melhor, maxPontos3o: cls[2]?.pontos ?? 0 }
   }
 
   const piorPosicao: Record<string, number> = {}


### PR DESCRIPTION
## Bug (produção)
Na página `/resultados`, em grupos **já encerrados**, o 2º colocado **não** recebia o selo ✓ quando empatava em **pontos** com o 3º:
- **Grupo B:** CAN (2º, 4 pts, **+5**) ficava sem ✓ — empatado com BIH (3º, 4 pts, -1)
- **Grupo D:** AUS (2º, 4 pts, **0**) ficava sem ✓ — empatado com PAR (3º, 4 pts, -2)

## Causa raiz
`analisarGrupo` (`clinchMataMata.ts`) calcula a posição por contagem **conservadora de pontos** (`pts[y] >= pts[x]`), tratando empate de pontos como "pode estar atrás". Correto enquanto há jogos por jogar (o saldo ainda muda), mas **errado em grupo completo**, onde o desempate por saldo já é definitivo.

## Correção
Em grupo completo (sem jogos restantes), usar a **classificação real** (`calcularClassificacaoGrupo`, com os critérios de desempate FIFA) para as posições — a mesma já usada em `/resultados`.

## Validação
- +1 teste de regressão · suíte **50/50** · typecheck + builds (front e functions) OK
- Validado contra os **dados reais de produção**: Grupo B → ✓ CAN, SUI · Grupo D → ✓ USA, AUS

🤖 Generated with [Claude Code](https://claude.com/claude-code)