### PR TITLE
fix(mata-mata): oitavas+ mostram times já classificados (cascata com alimentador não materializado)

### DIFF
--- a/src/lib/__tests__/resultadosOficiais.test.ts
+++ b/src/lib/__tests__/resultadosOficiais.test.ts
@@ -70,4 +70,39 @@ describe('montarResolvedorBracketOficial', () => {
     const resolver = montarResolvedorBracketOficial([...jogos, jogoMata], grupos)
     expect(resolver(jogoMata).casaId).toBe('BRA')
   })
+
+  it('resolve cascata W## para o VENCEDOR RESOLVIDO mesmo com alimentador não materializado (timeCasa vazio)', () => {
+    const grupos: GrupoRef[] = [{ nome: 'Grupo A', times: ['BRA', 'SRB', 'SUI', 'CMR'] }]
+    // Grupo A completo: BRA 1º (9), SRB 2º (6), SUI 3º (3), CMR 4º (0).
+    const jogos: Jogo[] = [
+      jogoGrupo('a1', 'A', 'BRA', 'SRB', [3, 0]),
+      jogoGrupo('a2', 'A', 'BRA', 'SUI', [3, 0]),
+      jogoGrupo('a3', 'A', 'BRA', 'CMR', [3, 0]),
+      jogoGrupo('a4', 'A', 'SRB', 'SUI', [1, 0]),
+      jogoGrupo('a5', 'A', 'SRB', 'CMR', [1, 0]),
+      jogoGrupo('a6', 'A', 'SUI', 'CMR', [1, 0]),
+    ]
+    // fase32 #73: 1A vs 2A, TIMES NÃO MATERIALIZADOS (timeCasa/Visitante = ''),
+    // encerrado 0x2 → vence o visitante (2A = SRB).
+    const fase32: Jogo = {
+      id: 'f73', numero: 73, fase: 'fase32', grupo: null,
+      timeCasa: '', timeVisitante: '', labelCasa: '1A', labelVisitante: '2A',
+      origemCasa: null, origemVisitante: null, dataHora: {} as never,
+      resultado: { golsCasa: 0, golsVisitante: 2, classificado: null }, encerrado: true,
+    }
+    // oitavas #89: casa = W73 (vencedor do 73), visitante = W74 (jogo inexistente/não jogado).
+    const oitavas: Jogo = {
+      id: 'o89', numero: 89, fase: 'oitavas', grupo: null,
+      timeCasa: '', timeVisitante: '', labelCasa: 'W73', labelVisitante: 'W74',
+      origemCasa: null, origemVisitante: null, dataHora: {} as never,
+      resultado: null, encerrado: false,
+    }
+    const resolver = montarResolvedorBracketOficial([...jogos, fase32, oitavas], grupos)
+    // o alimentador resolve seus próprios times pelos labels de grupo:
+    expect(resolver(fase32)).toEqual({ casaId: 'BRA', visitanteId: 'SRB' })
+    // a cascata resolve para o VENCEDOR RESOLVIDO (SRB), não para o '' cru:
+    expect(resolver(oitavas).casaId).toBe('SRB')
+    // o lado cujo alimentador ainda não foi jogado permanece indefinido:
+    expect(resolver(oitavas).visitanteId).toBeNull()
+  })
 })

--- a/src/lib/resultadosOficiais.ts
+++ b/src/lib/resultadosOficiais.ts
@@ -70,9 +70,25 @@ export function montarResolvedorBracketOficial(
   jogos: Jogo[],
   grupos: GrupoRef[],
 ): ResolverBracket {
-  return montarResolvedorBracket({
-    jogos,
-    grupos,
-    palpitesPorJogoId: jogosParaPalpitesReais(jogos),
-  })
+  const palpitesPorJogoId = jogosParaPalpitesReais(jogos)
+  const resolver = montarResolvedorBracket({ jogos, grupos, palpitesPorJogoId })
+
+  // Jogos de mata-mata têm timeCasa/Visitante vazios até serem materializados, então
+  // uma cascata (W##/RU##) resolveria o vencedor como string vazia. Resolvemos cada
+  // jogo na ordem de dependência (o alimentador sempre tem número menor) e enriquecemos
+  // o "palpite real" com os times JÁ RESOLVIDOS — assim as cascatas posteriores
+  // (oitavas ← fase32, quartas ← oitavas, …) encontram o time correto. Os palpites
+  // vêm de jogosParaPalpitesReais (objetos novos), então a mutação é segura.
+  const mataMata = jogos
+    .filter(j => j.fase !== 'grupos')
+    .sort((a, b) => (a.numero ?? 0) - (b.numero ?? 0))
+  for (const jogo of mataMata) {
+    const palpite = palpitesPorJogoId[jogo.id]
+    if (!palpite) continue // sem resultado → cascata permanece indefinida
+    const { casaId, visitanteId } = resolver(jogo)
+    if (casaId) palpite.timeCasa = casaId
+    if (visitanteId) palpite.timeVisitante = visitanteId
+  }
+
+  return resolver
 }


### PR DESCRIPTION
## Problema
As **oitavas** (e rodadas seguintes) não apresentavam os times que já se classificaram (vencedores das segundas de final já decididas).

## Causa raiz
Jogos de mata-mata têm `timeCasa`/`timeVisitante` vazios (`""`) até serem materializados. `jogoParaPalpiteReal` copia esses campos crus, então a cascata `W##`/`RU##` resolvia o vencedor como string vazia. Ex.: jogo #73 (fase32) encerrado 0-2 com `timeCasa=""` → `W73` retornava `""` em vez do vencedor (CAN).

## Correção
`montarResolvedorBracketOficial`: **forward-pass em ordem de número** (o alimentador sempre tem número menor) enriquecendo os "palpites reais" dos jogos de mata-mata já resolvidos com os times **resolvidos**, para as cascatas posteriores (oitavas ← fase32, quartas ← oitavas, semis ← quartas, final ← semis) acharem o time correto. Mutação segura (palpites são objetos novos de `jogosParaPalpitesReais`).

## Verificação
- Teste TDD: cascata `W73` com alimentador `timeCasa=""` resolve para o **vencedor resolvido** (não `""`). `npm test` **66/66**.
- Snapshot fresco (teste): `oitavas_2.casa = CAN` (W73 jogado), `oitavas_2.visitante = null` (W75 não jogado), demais oitavas null — assimetria correta.
- Visual (/resultados → Oitavas): **JOGO 90 🇨🇦 CAN vs W75**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)